### PR TITLE
SYS-2752: GH actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push: # Run CI on the main branch after every merge. This is important to fill the GitHub Actions cache in a way that pull requests can see it
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-20.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2022-10-18
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check Code
+        run: cargo fmt --all --check --manifest-path ./pallets/parachain-staking/Cargo.toml
+
+      - name: Test Code
+        run: cargo test --manifest-path ./pallets/parachain-staking/Cargo.toml
+
+      - name: Build
+        run: cargo build --locked --release --manifest-path ./pallets/parachain-staking/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Test Code
         run: cargo test
 
-      - name: benchmark test Code
-        run: cargo test --features runtime-benchmarks -- benchmarks
+      #- name: benchmark test Code
+      #  run: cargo test --features runtime-benchmarks -- benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,14 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check Code
-        run: cargo fmt --all --check --manifest-path ./pallets/parachain-staking/Cargo.toml
+      - name: Linting check
+        run: cargo fmt --all --check
+
+      - name: Check code
+        run: cargo check --locked --release
 
       - name: Test Code
-        run: cargo test --manifest-path ./pallets/parachain-staking/Cargo.toml
+        run: cargo test
 
-      - name: Build
-        run: cargo build --locked --release --manifest-path ./pallets/parachain-staking/Cargo.toml
+      - name: benchmark test Code
+        run: cargo test --features runtime-benchmarks -- benchmarks

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,7 @@ jobs:
           repository: Aventus-Network-Services/avn-node-parachain
           fetch-depth: '0'
           ssh-key: ${{ secrets.avn_node_parachain_key }}
+          ref: feat/SYS-2686-staking-reimplementation
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,35 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  integration_test:
+    name: integration-test
+    runs-on: ubuntu-20.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: Aventus-Network-Services/avn-node-parachain
+          fetch-depth: '0'
+          ssh-key: ${{ secrets.avn_node_parachain_key }}
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2022-10-18
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
+
+      - name: Task pre integration test
+        env:
+          STRING_TO_CHANGE: '\(pallet-parachain-staking =.*branch = \)\(.*\)\( }\)'
+        run: |
+          sed -i "s/$STRING_TO_CHANGE/\1\"$GITHUB_HEAD_REF\"\3/" ./runtime/Cargo.toml
+          echo "using staking pallet from branch:"
+          cat ./runtime/Cargo.toml | grep "^pallet-parachain-staking"
+
+      - name: Integration test
+        run: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Cargo compiled files and executables
 **/target/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Order is important; the last matching pattern takes the most precedence
+
+# global owners
+@nahuseyoum @alexpArtos @fluorostani @thadouk
+
+# CI OWNERS
+/.github/ @vukomir @RuiSMagalhaes


### PR DESCRIPTION
# WHAT
- CI pipeline that runs on PR to main and on push to main with:
  - cargo fmt check
  - cargo test 
  - cargo build
  - Integration test that will be required to merge a PR but only runs with a manual trigger.
- Codeowners added 

**NOTES**
- The pipeline will only work after:
  - doing a `cargo fmt` to the full repo
  - updating [this file](https://github.com/Aventus-Network-Services/avn-node-parachain/blob/main/runtime/Cargo.toml) to include the staking pallet
- PR's from outside collaborators **must need** approval to run the CI - this is extremely important security wise. A read only secret to our `avn-node-parachain` can be **exploited/exposed** otherwise.
- github action used to install rust-toolchain has last commit from Nov 2020 - we should track this and potentially change to another action since 2 years with almost no development means more untreated vulnerabilities. ([repo here](https://github.com/actions-rs/toolchain))

**TESTS**
- https://github.com/Aventus-Network-Services/avn-parachain/actions/runs/3315075759/jobs/5475185675
- https://github.com/Aventus-Network-Services/avn-parachain/actions/runs/3315075760/jobs/5475185699

**NEXT STEPS**
- change repo settings with best security practices in mind.
- Test CI on main branch (after making changes needed for the CI to run).
- test CI with with fork and test exploitation/hacking possibility.