### PR TITLE
Adds tab_spaces to rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,6 @@
 # Basic
 hard_tabs = false
+tab_spaces = 4
 max_width = 100
 use_small_heuristics = "Max"
 


### PR DESCRIPTION
Sets tab_spaces to 4 to match the original repo & team code style. https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#tab_spaces