### PR TITLE
SYS-2849 require session keys before joining as a collator

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -468,7 +468,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn selected_candidates)]
     /// The collator candidates selected for the current era
-    type SelectedCandidates<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+    pub type SelectedCandidates<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn total)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -228,7 +228,7 @@ pub mod pallet {
         SenderIsNotSigner,
         UnauthorizedSignedNominateTransaction,
         AdminSettingsValueIsNotValid,
-        CandidateNotRegisteredSessionKeys,
+        CandidateSessionKeysNotFound,
     }
 
     #[pallet::event]
@@ -740,7 +740,7 @@ pub mod pallet {
             ensure!(bond >= <MinCollatorStake<T>>::get(), Error::<T>::CandidateBondBelowMin);
             ensure!(
                 T::CollatorSessionRegistration::is_registered(&acc),
-                Error::<T>::CandidateNotRegisteredSessionKeys
+                Error::<T>::CandidateSessionKeysNotFound
             );
 
             let mut candidates = <CandidatePool<T>>::get();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -551,7 +551,7 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn new_era_forced)]
-    pub(crate) type ForceNewEra<T: Config> = StorageValue<_, bool, ValueQuery>;
+    pub type ForceNewEra<T: Config> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn min_collator_stake)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -91,7 +91,7 @@ pub mod pallet {
         pallet_prelude::*,
         traits::{
             tokens::WithdrawReasons, Currency, ExistenceRequirement, Get, Imbalance, IsSubType,
-            LockIdentifier, LockableCurrency, ReservableCurrency, ValidatorRegistration
+            LockIdentifier, LockableCurrency, ReservableCurrency, ValidatorRegistration,
         },
         weights::{GetDispatchInfo, PostDispatchInfo},
         PalletId,
@@ -739,9 +739,9 @@ pub mod pallet {
             ensure!(!Self::is_nominator(&acc), Error::<T>::NominatorExists);
             ensure!(bond >= <MinCollatorStake<T>>::get(), Error::<T>::CandidateBondBelowMin);
             ensure!(
-				T::CollatorSessionRegistration::is_registered(&acc),
-				Error::<T>::CandidateNotRegisteredSessionKeys
-			);
+                T::CollatorSessionRegistration::is_registered(&acc),
+                Error::<T>::CandidateNotRegisteredSessionKeys
+            );
 
             let mut candidates = <CandidatePool<T>>::get();
             let old_count = candidates.0.len() as u32;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -21,7 +21,7 @@ use frame_support::{
     assert_ok, construct_runtime, parameter_types,
     traits::{
         ConstU8, Currency, Everything, FindAuthor, GenesisBuild, Imbalance, LockIdentifier,
-        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration
+        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration,
     },
     weights::{DispatchClass, DispatchInfo, PostDispatchInfo, Weight, WeightToFee as WeightToFeeT},
     PalletId,
@@ -192,9 +192,9 @@ parameter_types! {
 
 pub struct IsRegistered;
 impl ValidatorRegistration<AccountId> for IsRegistered {
-	fn is_registered(_id: &AccountId) -> bool {
-		true
-	}
+    fn is_registered(_id: &AccountId) -> bool {
+        true
+    }
 }
 
 impl Config for Test {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -21,7 +21,7 @@ use frame_support::{
     assert_ok, construct_runtime, parameter_types,
     traits::{
         ConstU8, Currency, Everything, FindAuthor, GenesisBuild, Imbalance, LockIdentifier,
-        OnFinalize, OnInitialize, OnUnbalanced,
+        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration
     },
     weights::{DispatchClass, DispatchInfo, PostDispatchInfo, Weight, WeightToFee as WeightToFeeT},
     PalletId,
@@ -189,6 +189,14 @@ parameter_types! {
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
 }
+
+pub struct IsRegistered;
+impl ValidatorRegistration<AccountId> for IsRegistered {
+	fn is_registered(_id: &AccountId) -> bool {
+		true
+	}
+}
+
 impl Config for Test {
     type Call = Call;
     type Event = Event;
@@ -205,6 +213,7 @@ impl Config for Test {
     type ProcessedEventsChecker = ();
     type Public = AccountId;
     type Signature = Signature;
+    type CollatorSessionRegistration = IsRegistered;
     type WeightInfo = ();
 }
 


### PR DESCRIPTION
This PR adds an extra requirement of registering session keys before becoming a collator.