### PR TITLE
SYS-2851 update min nomination logic

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -34,7 +34,7 @@ fn min_candidate_stk<T: Config>() -> BalanceOf<T> {
 
 /// Minimum nominator stake
 fn min_nominator_stk<T: Config>() -> BalanceOf<T> {
-    <MinNominatorStake<T>>::get()
+    <MinTotalNominatorStake<T>>::get()
 }
 
 /// Create a funded user.
@@ -403,7 +403,7 @@ benchmarks! {
             )?;
             collators.push(collator.clone());
         }
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         let extra = if (bond * (collators.len() as u32 + 1u32).into()) > min_candidate_stk::<T>() {
             (bond * (collators.len() as u32 + 1u32).into()) - min_candidate_stk::<T>()
         } else {
@@ -455,7 +455,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(RawOrigin::Signed(
             caller.clone()).into(),
             collator.clone(),
@@ -488,7 +488,7 @@ benchmarks! {
             )?;
             collators.push(collator.clone());
         }
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         let need = bond * (collators.len() as u32).into();
         let default_minted = min_candidate_stk::<T>();
         let need: BalanceOf<T> = if need > default_minted {
@@ -528,7 +528,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(RawOrigin::Signed(
             caller.clone()).into(),
             collator.clone(),
@@ -551,7 +551,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(RawOrigin::Signed(
             caller.clone()).into(),
             collator.clone(),
@@ -580,7 +580,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(
             RawOrigin::Signed(caller.clone()).into(),
             collator.clone(),
@@ -610,7 +610,7 @@ benchmarks! {
             0u32,
             0u32
         )?;
-        let bond_less = <MinNominatorStake<T>>::get();
+        let bond_less = <MinTotalNominatorStake<T>>::get();
     }: _(RawOrigin::Signed(caller.clone()), collator.clone(), bond_less)
     verify {
         let state = Pallet::<T>::nominator_state(&caller)
@@ -634,7 +634,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(RawOrigin::Signed(
             caller.clone()).into(),
             collator.clone(),
@@ -675,7 +675,7 @@ benchmarks! {
             0u32,
             0u32
         )?;
-        let bond_less = <MinNominatorStake<T>>::get();
+        let bond_less = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::schedule_nominator_bond_less(
             RawOrigin::Signed(caller.clone()).into(),
             collator.clone(),
@@ -702,7 +702,7 @@ benchmarks! {
             1u32
         )?;
         let (caller, _) = create_funded_user::<T>("caller", USER_SEED, 0u32.into());
-        let bond = <MinNominatorStake<T>>::get();
+        let bond = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::nominate(RawOrigin::Signed(
             caller.clone()).into(),
             collator.clone(),
@@ -743,7 +743,7 @@ benchmarks! {
             0u32,
             0u32
         )?;
-        let bond_less = <MinNominatorStake<T>>::get();
+        let bond_less = <MinTotalNominatorStake<T>>::get();
         Pallet::<T>::schedule_nominator_bond_less(
             RawOrigin::Signed(caller.clone()).into(),
             collator.clone(),
@@ -847,7 +847,7 @@ benchmarks! {
                         if let Ok(_) = Pallet::<T>::nominate(RawOrigin::Signed(
                             caller.clone()).into(),
                             col.clone(),
-                            <MinNominatorStake<T>>::get(),
+                            <MinTotalNominatorStake<T>>::get(),
                             *n_count,
                             collators.len() as u32, // overestimate
                         ) {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -468,7 +468,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn selected_candidates)]
     /// The collator candidates selected for the current era
-    type SelectedCandidates<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+    pub type SelectedCandidates<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn total)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -228,7 +228,7 @@ pub mod pallet {
         SenderIsNotSigner,
         UnauthorizedSignedNominateTransaction,
         AdminSettingsValueIsNotValid,
-        CandidateNotRegisteredSessionKeys,
+        CandidateSessionKeysNotFound,
     }
 
     #[pallet::event]
@@ -740,7 +740,7 @@ pub mod pallet {
             ensure!(bond >= <MinCollatorStake<T>>::get(), Error::<T>::CandidateBondBelowMin);
             ensure!(
                 T::CollatorSessionRegistration::is_registered(&acc),
-                Error::<T>::CandidateNotRegisteredSessionKeys
+                Error::<T>::CandidateSessionKeysNotFound
             );
 
             let mut candidates = <CandidatePool<T>>::get();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -551,7 +551,7 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn new_era_forced)]
-    pub(crate) type ForceNewEra<T: Config> = StorageValue<_, bool, ValueQuery>;
+    pub type ForceNewEra<T: Config> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn min_collator_stake)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -40,8 +40,8 @@
 //! original request was made.
 //!
 //! To join the set of nominators, call `nominate` and pass in an account that is
-//! already a collator candidate and `bond >= MinTotalNominatorStake`. Each nominator can nominate up to
-//! `T::MaxNominationsPerNominator` collator candidates by calling `nominate`.
+//! already a collator candidate and `bond >= MinTotalNominatorStake`. Each nominator can nominate
+//! up to `T::MaxNominationsPerNominator` collator candidates by calling `nominate`.
 //!
 //! To revoke a nomination, call `revoke_nomination` with the collator candidate's account.
 //! To leave the set of nominators and revoke all nominations, call `leave_nominators`.
@@ -560,7 +560,8 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn min_total_nominator_stake)]
-    /// Minimum total stake that must be maintained for any registered on-chain account to be a nominator
+    /// Minimum total stake that must be maintained for any registered on-chain account to be a
+    /// nominator
     pub type MinTotalNominatorStake<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[pallet::storage]
@@ -1026,7 +1027,10 @@ pub mod pallet {
             let mut nominator_state = if let Some(mut state) = <NominatorState<T>>::get(&nominator)
             {
                 // The min amount for subsequent nominations on additional collators.
-                ensure!(amount >= T::MinNominationPerCollator::get(), Error::<T>::NominationBelowMin);
+                ensure!(
+                    amount >= T::MinNominationPerCollator::get(),
+                    Error::<T>::NominationBelowMin
+                );
                 ensure!(
                     nomination_count >= state.nominations.0.len() as u32,
                     Error::<T>::TooLowNominationCountToNominate
@@ -1042,7 +1046,10 @@ pub mod pallet {
                 state
             } else {
                 // first nomination
-                ensure!(amount >= <MinTotalNominatorStake<T>>::get(), Error::<T>::NominatorBondBelowMin);
+                ensure!(
+                    amount >= <MinTotalNominatorStake<T>>::get(),
+                    Error::<T>::NominatorBondBelowMin
+                );
                 ensure!(!Self::is_candidate(&nominator), Error::<T>::CandidateExists);
                 Nominator::new(nominator.clone(), candidate.clone(), amount)
             };

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -40,7 +40,7 @@
 //! original request was made.
 //!
 //! To join the set of nominators, call `nominate` and pass in an account that is
-//! already a collator candidate and `bond >= MinNominatorStake`. Each nominator can nominate up to
+//! already a collator candidate and `bond >= MinTotalNominatorStake`. Each nominator can nominate up to
 //! `T::MaxNominationsPerNominator` collator candidates by calling `nominate`.
 //!
 //! To revoke a nomination, call `revoke_nomination` with the collator candidate's account.
@@ -154,9 +154,9 @@ pub mod pallet {
         /// Maximum nominations per nominator
         #[pallet::constant]
         type MaxNominationsPerNominator: Get<u32>;
-        /// Minimum stake for any registered on-chain account to nominate
+        /// Minimum stake, per collator, that must be maintained by an account that is nominating
         #[pallet::constant]
-        type MinNomination: Get<BalanceOf<Self>>;
+        type MinNominationPerCollator: Get<BalanceOf<Self>>;
         /// Number of eras to wait before we process a new growth period
         type ErasPerGrowthPeriod: Get<GrowthPeriodIndex>;
         /// Id of the account that will hold funds to be paid as staking reward
@@ -559,9 +559,9 @@ pub mod pallet {
     pub type MinCollatorStake<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[pallet::storage]
-    #[pallet::getter(fn min_nominator_stake)]
-    /// Minimum stake for any registered on-chain account to be a nominator
-    pub type MinNominatorStake<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+    #[pallet::getter(fn min_total_nominator_stake)]
+    /// Minimum total stake that must be maintained for any registered on-chain account to be a nominator
+    pub type MinTotalNominatorStake<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn proxy_nonce)]
@@ -576,7 +576,7 @@ pub mod pallet {
         pub nominations: Vec<(T::AccountId, T::AccountId, BalanceOf<T>)>,
         pub delay: EraIndex,
         pub min_collator_stake: BalanceOf<T>,
-        pub min_nominator_stake: BalanceOf<T>,
+        pub min_total_nominator_stake: BalanceOf<T>,
     }
 
     #[cfg(feature = "std")]
@@ -587,7 +587,7 @@ pub mod pallet {
                 nominations: vec![],
                 delay: Default::default(),
                 min_collator_stake: Default::default(),
-                min_nominator_stake: Default::default(),
+                min_total_nominator_stake: Default::default(),
             }
         }
     }
@@ -653,7 +653,7 @@ pub mod pallet {
 
             // Set min staking values
             <MinCollatorStake<T>>::put(self.min_collator_stake);
-            <MinNominatorStake<T>>::put(self.min_nominator_stake);
+            <MinTotalNominatorStake<T>>::put(self.min_total_nominator_stake);
 
             // Set total selected candidates to minimum config
             <TotalSelected<T>>::put(T::MinSelectedCandidates::get());
@@ -1025,8 +1025,8 @@ pub mod pallet {
             );
             let mut nominator_state = if let Some(mut state) = <NominatorState<T>>::get(&nominator)
             {
-                // nomination after first
-                ensure!(amount >= T::MinNomination::get(), Error::<T>::NominationBelowMin);
+                // The min amount for subsequent nominations on additional collators.
+                ensure!(amount >= T::MinNominationPerCollator::get(), Error::<T>::NominationBelowMin);
                 ensure!(
                     nomination_count >= state.nominations.0.len() as u32,
                     Error::<T>::TooLowNominationCountToNominate
@@ -1042,7 +1042,7 @@ pub mod pallet {
                 state
             } else {
                 // first nomination
-                ensure!(amount >= <MinNominatorStake<T>>::get(), Error::<T>::NominatorBondBelowMin);
+                ensure!(amount >= <MinTotalNominatorStake<T>>::get(), Error::<T>::NominatorBondBelowMin);
                 ensure!(!Self::is_candidate(&nominator), Error::<T>::CandidateExists);
                 Nominator::new(nominator.clone(), candidate.clone(), amount)
             };
@@ -1226,7 +1226,7 @@ pub mod pallet {
             match value {
                 AdminSettings::Delay(d) => <Delay<T>>::put(d),
                 AdminSettings::MinCollatorStake(s) => <MinCollatorStake<T>>::put(s),
-                AdminSettings::MinNominatorStake(s) => <MinNominatorStake<T>>::put(s),
+                AdminSettings::MinTotalNominatorStake(s) => <MinTotalNominatorStake<T>>::put(s),
             }
 
             Self::deposit_event(Event::AdminSettingsUpdated { value });
@@ -1272,12 +1272,15 @@ pub mod pallet {
         pub fn is_nominator(acc: &T::AccountId) -> bool {
             <NominatorState<T>>::get(acc).is_some()
         }
+
         pub fn is_candidate(acc: &T::AccountId) -> bool {
             <CandidateInfo<T>>::get(acc).is_some()
         }
+
         pub fn is_selected_candidate(acc: &T::AccountId) -> bool {
             <SelectedCandidates<T>>::get().binary_search(acc).is_ok()
         }
+
         /// Returns an account's free balance which is not locked in nomination staking
         pub fn get_nominator_stakable_free_balance(acc: &T::AccountId) -> BalanceOf<T> {
             let mut balance = T::Currency::free_balance(acc);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -91,7 +91,7 @@ pub mod pallet {
         pallet_prelude::*,
         traits::{
             tokens::WithdrawReasons, Currency, ExistenceRequirement, Get, Imbalance, IsSubType,
-            LockIdentifier, LockableCurrency, ReservableCurrency, ValidatorRegistration
+            LockIdentifier, LockableCurrency, ReservableCurrency, ValidatorRegistration,
         },
         weights::{GetDispatchInfo, PostDispatchInfo},
         PalletId,
@@ -739,9 +739,9 @@ pub mod pallet {
             ensure!(!Self::is_nominator(&acc), Error::<T>::NominatorExists);
             ensure!(bond >= <MinCollatorStake<T>>::get(), Error::<T>::CandidateBondBelowMin);
             ensure!(
-				T::CollatorSessionRegistration::is_registered(&acc),
-				Error::<T>::CandidateNotRegisteredSessionKeys
-			);
+                T::CollatorSessionRegistration::is_registered(&acc),
+                Error::<T>::CandidateNotRegisteredSessionKeys
+            );
 
             let mut candidates = <CandidatePool<T>>::get();
             let old_count = candidates.0.len() as u32;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -21,7 +21,7 @@ use frame_support::{
     assert_ok, construct_runtime, parameter_types,
     traits::{
         ConstU8, Currency, Everything, FindAuthor, GenesisBuild, Imbalance, LockIdentifier,
-        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration
+        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration,
     },
     weights::{DispatchClass, DispatchInfo, PostDispatchInfo, Weight, WeightToFee as WeightToFeeT},
     PalletId,
@@ -192,9 +192,9 @@ parameter_types! {
 
 pub struct IsRegistered;
 impl ValidatorRegistration<AccountId> for IsRegistered {
-	fn is_registered(_id: &AccountId) -> bool {
-		true
-	}
+    fn is_registered(_id: &AccountId) -> bool {
+        true
+    }
 }
 
 impl Config for Test {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -185,7 +185,7 @@ parameter_types! {
     pub const MaxTopNominationsPerCandidate: u32 = 4;
     pub const MaxBottomNominationsPerCandidate: u32 = 4;
     pub const MaxNominationsPerNominator: u32 = 4;
-    pub const MinNomination: u128 = 3;
+    pub const MinNominationPerCollator: u128 = 3;
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
 }
@@ -207,7 +207,7 @@ impl Config for Test {
     type MaxTopNominationsPerCandidate = MaxTopNominationsPerCandidate;
     type MaxBottomNominationsPerCandidate = MaxBottomNominationsPerCandidate;
     type MaxNominationsPerNominator = MaxNominationsPerNominator;
-    type MinNomination = MinNomination;
+    type MinNominationPerCollator = MinNominationPerCollator;
     type RewardPotId = RewardPotId;
     type ErasPerGrowthPeriod = ErasPerGrowthPeriod;
     type ProcessedEventsChecker = ();
@@ -330,7 +330,7 @@ impl ExtBuilder {
             nominations: self.nominations,
             delay: 2,
             min_collator_stake: 10,
-            min_nominator_stake: 5,
+            min_total_nominator_stake: 5,
         }
         .assimilate_storage(&mut t)
         .expect("Parachain Staking's storage can be assimilated");

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -21,7 +21,7 @@ use frame_support::{
     assert_ok, construct_runtime, parameter_types,
     traits::{
         ConstU8, Currency, Everything, FindAuthor, GenesisBuild, Imbalance, LockIdentifier,
-        OnFinalize, OnInitialize, OnUnbalanced,
+        OnFinalize, OnInitialize, OnUnbalanced, ValidatorRegistration
     },
     weights::{DispatchClass, DispatchInfo, PostDispatchInfo, Weight, WeightToFee as WeightToFeeT},
     PalletId,
@@ -189,6 +189,14 @@ parameter_types! {
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
 }
+
+pub struct IsRegistered;
+impl ValidatorRegistration<AccountId> for IsRegistered {
+	fn is_registered(_id: &AccountId) -> bool {
+		true
+	}
+}
+
 impl Config for Test {
     type Call = Call;
     type Event = Event;
@@ -205,6 +213,7 @@ impl Config for Test {
     type ProcessedEventsChecker = ();
     type Public = AccountId;
     type Signature = Signature;
+    type CollatorSessionRegistration = IsRegistered;
     type WeightInfo = ();
 }
 

--- a/pallets/parachain-staking/src/nomination_requests.rs
+++ b/pallets/parachain-staking/src/nomination_requests.rs
@@ -18,8 +18,8 @@
 
 use crate::{
     pallet::{
-        BalanceOf, CandidateInfo, Config, Delay, Era, EraIndex, Error, Event, MinTotalNominatorStake,
-        NominationScheduledRequests, NominatorState, Pallet, Total,
+        BalanceOf, CandidateInfo, Config, Delay, Era, EraIndex, Error, Event,
+        MinTotalNominatorStake, NominationScheduledRequests, NominatorState, Pallet, Total,
     },
     Nominator, NominatorStatus,
 };
@@ -128,7 +128,8 @@ impl<T: Config> Pallet<T> {
         // Net Total is total after pending orders are executed
         let net_total = state.total().saturating_sub(state.less_total);
         // Net Total is always >= MinTotalNominatorStake
-        let max_subtracted_amount = net_total.saturating_sub(<MinTotalNominatorStake<T>>::get().into());
+        let max_subtracted_amount =
+            net_total.saturating_sub(<MinTotalNominatorStake<T>>::get().into());
         ensure!(decrease_amount <= max_subtracted_amount, <Error<T>>::NominatorBondBelowMin);
 
         let now = <Era<T>>::get().current;

--- a/pallets/parachain-staking/src/nomination_requests.rs
+++ b/pallets/parachain-staking/src/nomination_requests.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     pallet::{
-        BalanceOf, CandidateInfo, Config, Delay, Era, EraIndex, Error, Event, MinNominatorStake,
+        BalanceOf, CandidateInfo, Config, Delay, Era, EraIndex, Error, Event, MinTotalNominatorStake,
         NominationScheduledRequests, NominatorState, Pallet, Total,
     },
     Nominator, NominatorStatus,
@@ -123,12 +123,12 @@ impl<T: Config> Pallet<T> {
         let bonded_amount = state.get_bond_amount(&collator).ok_or(<Error<T>>::NominationDNE)?;
         ensure!(bonded_amount > decrease_amount, <Error<T>>::NominatorBondBelowMin);
         let new_amount: BalanceOf<T> = (bonded_amount - decrease_amount).into();
-        ensure!(new_amount >= T::MinNomination::get(), <Error<T>>::NominationBelowMin);
+        ensure!(new_amount >= T::MinNominationPerCollator::get(), <Error<T>>::NominationBelowMin);
 
         // Net Total is total after pending orders are executed
         let net_total = state.total().saturating_sub(state.less_total);
-        // Net Total is always >= MinNominatorStake
-        let max_subtracted_amount = net_total.saturating_sub(<MinNominatorStake<T>>::get().into());
+        // Net Total is always >= MinTotalNominatorStake
+        let max_subtracted_amount = net_total.saturating_sub(<MinTotalNominatorStake<T>>::get().into());
         ensure!(decrease_amount <= max_subtracted_amount, <Error<T>>::NominatorBondBelowMin);
 
         let now = <Era<T>>::get().current;
@@ -210,7 +210,7 @@ impl<T: Config> Pallet<T> {
                     true
                 } else {
                     ensure!(
-                        state.total().saturating_sub(<MinNominatorStake<T>>::get().into()) >=
+                        state.total().saturating_sub(<MinTotalNominatorStake<T>>::get().into()) >=
                             amount,
                         <Error<T>>::NominatorBondBelowMin
                     );
@@ -261,11 +261,11 @@ impl<T: Config> Pallet<T> {
                             state.total_sub_if::<T, _>(amount, |total| {
                                 let new_total: BalanceOf<T> = total.into();
                                 ensure!(
-                                    new_total >= T::MinNomination::get(),
+                                    new_total >= T::MinNominationPerCollator::get(),
                                     <Error<T>>::NominationBelowMin
                                 );
                                 ensure!(
-                                    new_total >= <MinNominatorStake<T>>::get(),
+                                    new_total >= <MinTotalNominatorStake<T>>::get(),
                                     <Error<T>>::NominatorBondBelowMin
                                 );
 

--- a/pallets/parachain-staking/src/test_admin_settings.rs
+++ b/pallets/parachain-staking/src/test_admin_settings.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 use crate::mock::{
-    Event as MetaEvent, ExtBuilder, MinNominationPerCollator, Origin, ParachainStaking, Test, TestAccount,
+    Event as MetaEvent, ExtBuilder, MinNominationPerCollator, Origin, ParachainStaking, Test,
+    TestAccount,
 };
 use crate::{
     assert_last_event, AdminSettings, BalanceOf, Delay, Error, Event, MinCollatorStake,

--- a/pallets/parachain-staking/src/test_admin_settings.rs
+++ b/pallets/parachain-staking/src/test_admin_settings.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 use crate::mock::{
-    Event as MetaEvent, ExtBuilder, MinNomination, Origin, ParachainStaking, Test, TestAccount,
+    Event as MetaEvent, ExtBuilder, MinNominationPerCollator, Origin, ParachainStaking, Test, TestAccount,
 };
 use crate::{
     assert_last_event, AdminSettings, BalanceOf, Delay, Error, Event, MinCollatorStake,
-    MinNominatorStake,
+    MinTotalNominatorStake,
 };
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
@@ -83,16 +83,16 @@ mod min_nominator_stake_admin_setting {
     #[test]
     fn can_be_updated() {
         ExtBuilder::default().build().execute_with(|| {
-            let new_min_value = <MinNominatorStake<Test>>::get() - 1;
+            let new_min_value = <MinTotalNominatorStake<Test>>::get() - 1;
             let new_min_setting =
-                AdminSettings::<BalanceOf<Test>>::MinNominatorStake(new_min_value);
+                AdminSettings::<BalanceOf<Test>>::MinTotalNominatorStake(new_min_value);
 
             assert_ok!(ParachainStaking::set_admin_setting(
                 Origin::root(),
                 new_min_setting.clone()
             ));
 
-            assert_eq!(<MinNominatorStake<Test>>::get(), new_min_value);
+            assert_eq!(<MinTotalNominatorStake<Test>>::get(), new_min_value);
             assert_last_event!(MetaEvent::ParachainStaking(Event::AdminSettingsUpdated {
                 value: new_min_setting
             }));
@@ -102,9 +102,9 @@ mod min_nominator_stake_admin_setting {
     #[test]
     fn updating_fails_if_value_is_below_min_nominations() {
         ExtBuilder::default().build().execute_with(|| {
-            let bad_min_value = MinNomination::get() - 1;
+            let bad_min_value = MinNominationPerCollator::get() - 1;
             let new_min_setting =
-                AdminSettings::<BalanceOf<Test>>::MinNominatorStake(bad_min_value);
+                AdminSettings::<BalanceOf<Test>>::MinTotalNominatorStake(bad_min_value);
 
             assert_noop!(
                 ParachainStaking::set_admin_setting(Origin::root(), new_min_setting.clone()),

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2440,7 +2440,7 @@ fn cannot_revoke_nomination_that_dne() {
 
 #[test]
 // See `cannot_execute_revoke_nomination_below_min_nominator_stake` for where the "must be above
-// MinNominatorStake" rule is now enforced.
+// MinTotalNominatorStake" rule is now enforced.
 fn can_schedule_revoke_nomination_below_min_nominator_stake() {
     let account_id = to_acc_id(1u64);
     let account_id_2 = to_acc_id(2u64);

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -1140,7 +1140,7 @@ impl<
             false
         }
     }
-    // Return Some(remaining balance), must be more than MinNominatorStake
+    // Return Some(remaining balance), must be more than MinTotalNominatorStake
     // Return None if nomination not found
     pub fn rm_nomination<T: Config>(&mut self, collator: &AccountId) -> Option<Balance>
     where
@@ -1418,7 +1418,7 @@ pub enum AdminSettings<Balance> {
     /// Minimum collator stake amount
     MinCollatorStake(Balance),
     /// Minimum nominator stake amount
-    MinNominatorStake(Balance),
+    MinTotalNominatorStake(Balance),
 }
 
 impl<
@@ -1440,8 +1440,8 @@ impl<
     {
         return match self {
             AdminSettings::Delay(d) => d > &0,
-            AdminSettings::MinNominatorStake(s) =>
-                s >= &<<T as Config>::MinNomination as Get<BalanceOf<T>>>::get().into(),
+            AdminSettings::MinTotalNominatorStake(s) =>
+                s >= &<<T as Config>::MinNominationPerCollator as Get<BalanceOf<T>>>::get().into(),
             AdminSettings::MinCollatorStake(_) => true,
             _ => false,
         }


### PR DESCRIPTION
This PR renames:
-  `MinNominatorStake` -> `MinTotalNominatorStake` and 
- `MinNomination` -> `MinNominationPerCollator`

The first is the minimum total stake that must be maintained by a account to stay as a nominator. The second value is the minimum nomination they must maintain for each collator.