### PR TITLE
SYS-2825 rename extrinsic and move logic to calls

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -571,7 +571,7 @@ benchmarks! {
         );
     }
 
-    nominator_bond_more {
+    bond_extra {
         let collator: T::AccountId = create_funded_collator::<T>(
             "collator",
             USER_SEED,

--- a/pallets/parachain-staking/src/calls.rs
+++ b/pallets/parachain-staking/src/calls.rs
@@ -70,4 +70,20 @@ impl<T: Config> Pallet<T> {
 
         Ok(().into())
     }
+
+    pub fn call_bond_extra(
+        nominator: &T::AccountId,
+        candidate: T::AccountId,
+        additional_amount: BalanceOf<T>) -> DispatchResultWithPostInfo
+    {
+        ensure!(
+            !Self::nomination_request_revoke_exists(&candidate, nominator),
+            Error::<T>::PendingNominationRevoke
+        );
+
+        let mut state = <NominatorState<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;
+        state.increase_nomination::<T>(candidate.clone(), additional_amount)?;
+
+        Ok(().into())
+    }
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1160,9 +1160,9 @@ pub mod pallet {
             Self::nomination_schedule_revoke(collator, nominator)
         }
 
-        #[pallet::weight(<T as Config>::WeightInfo::nominator_bond_more())]
+        #[pallet::weight(<T as Config>::WeightInfo::bond_extra())]
         /// Bond more for nominators wrt a specific collator candidate.
-        pub fn nominator_bond_more(
+        pub fn bond_extra(
             origin: OriginFor<T>,
             candidate: T::AccountId,
             more: BalanceOf<T>,

--- a/pallets/parachain-staking/src/tests/tests.rs
+++ b/pallets/parachain-staking/src/tests/tests.rs
@@ -2021,7 +2021,7 @@ fn nominator_bond_more_reserves_balance() {
         .build()
         .execute_with(|| {
             assert_eq!(ParachainStaking::get_nominator_stakable_free_balance(&account_id_2), 5);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2041,7 +2041,7 @@ fn nominator_bond_more_increases_total_staked() {
         .build()
         .execute_with(|| {
             assert_eq!(ParachainStaking::total(), 40);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2064,7 +2064,7 @@ fn nominator_bond_more_updates_nominator_state() {
                 ParachainStaking::nominator_state(account_id_2).expect("exists").total(),
                 10
             );
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2095,7 +2095,7 @@ fn nominator_bond_more_updates_candidate_state_top_nominations() {
                 10
             );
             assert_eq!(ParachainStaking::top_nominations(account_id).unwrap().total, 10);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2146,7 +2146,7 @@ fn nominator_bond_more_updates_candidate_state_bottom_nominations() {
                 10
             );
             assert_eq!(ParachainStaking::bottom_nominations(account_id).unwrap().total, 10);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2182,7 +2182,7 @@ fn nominator_bond_more_increases_total() {
         .build()
         .execute_with(|| {
             assert_eq!(ParachainStaking::total(), 40);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2202,7 +2202,7 @@ fn can_nominator_bond_more_for_leaving_candidate() {
         .build()
         .execute_with(|| {
             assert_ok!(ParachainStaking::schedule_leave_candidates(Origin::signed(account_id), 1));
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2225,7 +2225,7 @@ fn nominator_bond_more_disallowed_when_revoke_scheduled() {
                 account_id
             ));
             assert_noop!(
-                ParachainStaking::nominator_bond_more(Origin::signed(account_id_2), account_id, 5),
+                ParachainStaking::bond_extra(Origin::signed(account_id_2), account_id, 5),
                 <Error<Test>>::PendingNominationRevoke
             );
         });
@@ -2246,7 +2246,7 @@ fn nominator_bond_more_allowed_when_bond_decrease_scheduled() {
                 account_id,
                 5,
             ));
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id,
                 5
@@ -2871,7 +2871,7 @@ fn nominator_bond_more_after_revoke_nomination_does_not_effect_exit() {
                 Origin::signed(account_id_2),
                 account_id
             ));
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_2),
                 account_id_3,
                 10
@@ -5965,7 +5965,7 @@ fn candidate_pool_updates_when_total_counted_changes() {
             }
             // 15 + 16 + 17 + 18 + 20 = 86 (top 4 + self bond)
             is_candidate_pool_bond(account_id, 86);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_3),
                 account_id,
                 8
@@ -5973,7 +5973,7 @@ fn candidate_pool_updates_when_total_counted_changes() {
             // 3: 11 -> 19 => 3 is in top, bumps out 7
             // 16 + 17 + 18 + 19 + 20 = 90 (top 4 + self bond)
             is_candidate_pool_bond(account_id, 90);
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(to_acc_id(4)),
                 account_id,
                 8
@@ -6051,7 +6051,7 @@ fn only_top_collators_are_counted() {
             // 15 + 16 + 17 + 18 + 20 = 86 (top 4 + self bond)
             assert_eq!(collator_state.total_counted, 86);
             // bump bottom to the top
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_3),
                 account_id,
                 8
@@ -6066,7 +6066,7 @@ fn only_top_collators_are_counted() {
             // 16 + 17 + 18 + 19 + 20 = 90 (top 4 + self bond)
             assert_eq!(collator_state.total_counted, 90);
             // bump bottom to the top
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_4),
                 account_id,
                 8
@@ -6081,7 +6081,7 @@ fn only_top_collators_are_counted() {
             // 17 + 18 + 19 + 20 + 20 = 94 (top 4 + self bond)
             assert_eq!(collator_state.total_counted, 94);
             // bump bottom to the top
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_5),
                 account_id,
                 8
@@ -6096,7 +6096,7 @@ fn only_top_collators_are_counted() {
             // 18 + 19 + 20 + 21 + 20 = 98 (top 4 + self bond)
             assert_eq!(collator_state.total_counted, 98);
             // bump bottom to the top
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(account_id_6),
                 account_id,
                 8
@@ -6178,7 +6178,7 @@ fn nomination_events_convey_correct_position() {
             // 12 + 13 + 14 + 15 + 20 = 70 (top 4 + self bond)
             assert_eq!(collator1_state.total_counted, 74);
             // 8 increases nomination to the top
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(to_acc_id(8)),
                 account_id,
                 3
@@ -6193,7 +6193,7 @@ fn nomination_events_convey_correct_position() {
             // 13 + 13 + 14 + 15 + 20 = 75 (top 4 + self bond)
             assert_eq!(collator1_state.total_counted, 75);
             // 3 increases nomination but stays in bottom
-            assert_ok!(ParachainStaking::nominator_bond_more(
+            assert_ok!(ParachainStaking::bond_extra(
                 Origin::signed(to_acc_id(3)),
                 account_id,
                 1

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -93,7 +93,7 @@ pub trait WeightInfo {
     #[rustfmt::skip]
 	fn schedule_revoke_nomination() -> Weight;
     #[rustfmt::skip]
-	fn nominator_bond_more() -> Weight;
+	fn bond_extra() -> Weight;
     #[rustfmt::skip]
 	fn schedule_nominator_bond_less() -> Weight;
     #[rustfmt::skip]
@@ -312,7 +312,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     // Storage: ParachainStaking CandidatePool (r:1 w:1)
     // Storage: ParachainStaking Total (r:1 w:1)
 	#[rustfmt::skip]
-    fn nominator_bond_more() -> Weight {
+    fn bond_extra() -> Weight {
 		(66_476_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
@@ -621,7 +621,7 @@ impl WeightInfo for () {
     // Storage: ParachainStaking CandidatePool (r:1 w:1)
     // Storage: ParachainStaking Total (r:1 w:1)
 	#[rustfmt::skip]
-    fn nominator_bond_more() -> Weight {
+    fn bond_extra() -> Weight {
 		(66_476_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))


### PR DESCRIPTION
This PR moves extrinsic logic for `nominator_bond_more` into `calls.rs` and renamed `nominator_bond_more` -> `bond_extra`