### PR TITLE
SYS-2686 bug fix for rounding issues

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2128,7 +2128,9 @@ pub mod pallet {
             number_of_collators: u64,
             index: u64,
         ) -> bool {
-            if dust.is_zero() { return false }
+            if dust.is_zero() {
+                return false
+            }
 
             let block_number: u64 =
                 TryInto::<u64>::try_into(<frame_system::Pallet<T>>::block_number())

--- a/pallets/parachain-staking/src/migration.rs
+++ b/pallets/parachain-staking/src/migration.rs
@@ -23,7 +23,7 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 pub fn enable_staking<T: Config>() -> Weight {
     let initial_delay: u32 = 2;
     let initial_min_collator_stake = 5_000_000_000_000_000_000_000u128; //5000AVT
-    let initial_min_user_stake = 100_000_000_000_000_000_000u128; // 100 AVT
+    let initial_min_user_stake = 10_000_000_000_000_000_000u128; // 10 AVT (100 in total)
     let intial_blocks_per_era = 7_200u32; // 24 HOURS (12sec per block)
     let intial_era_index = 1u32;
     let initial_growth_period_index = 0u32;

--- a/pallets/parachain-staking/src/tests/nominate_tests.rs
+++ b/pallets/parachain-staking/src/tests/nominate_tests.rs
@@ -194,7 +194,7 @@ mod proxy_signed_nominate {
                 // Nonce has increased
                 assert_eq!(ParachainStaking::proxy_nonce(staker.account_id), nonce + 1);
             })
-        }
+    }
 
     mod fails_when {
         use super::*;

--- a/pallets/parachain-staking/src/tests/nominate_tests.rs
+++ b/pallets/parachain-staking/src/tests/nominate_tests.rs
@@ -138,6 +138,64 @@ mod proxy_signed_nominate {
             })
     }
 
+    #[test]
+    fn succeeds_with_negative_dust() {
+        let collator_1 = to_acc_id(1u64);
+        let collator_2 = to_acc_id(2u64);
+        let collator_3 = to_acc_id(3u64);
+        let collator_4 = to_acc_id(4u64);
+        let collator_5 = to_acc_id(5u64);
+        let staker: Staker = Default::default();
+        let initial_collator_stake = 1000;
+        let initial_balance = 596583960081717817908u128;
+        ExtBuilder::default()
+            .with_balances(vec![
+                (collator_1, initial_balance),
+                (collator_2, initial_balance),
+                (collator_3, initial_balance),
+                (collator_4, initial_balance),
+                (collator_5, initial_balance),
+                (staker.account_id, initial_balance),
+                (staker.relayer, initial_balance),
+            ])
+            .with_candidates(vec![
+                (collator_1, initial_collator_stake),
+                (collator_2, initial_collator_stake),
+                (collator_3, initial_collator_stake),
+                (collator_4, initial_collator_stake),
+                (collator_5, initial_collator_stake),
+            ])
+            .build()
+            .execute_with(|| {
+                // Pick an amount that is not perfectly divisible by the number of collators
+                // 496583960081717817908 / 5 * 5 will give 496583960081717817910 due to rounding
+                let amount_to_stake = 496583960081717817908u128;
+                let nonce = ParachainStaking::proxy_nonce(staker.account_id);
+                let nominate_call = create_call_for_nominate(
+                    &staker,
+                    nonce,
+                    vec![collator_1, collator_2, collator_3, collator_4, collator_5],
+                    amount_to_stake,
+                );
+
+                assert_ok!(AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None));
+
+                let staker_state = ParachainStaking::nominator_state(staker.account_id).unwrap();
+
+                // The staker state has also been updated
+                assert_eq!(staker_state.total(), amount_to_stake);
+
+                // The staker free balance has been reduced
+                assert_eq!(
+                    ParachainStaking::get_nominator_stakable_free_balance(&staker.account_id),
+                    initial_balance - amount_to_stake
+                );
+
+                // Nonce has increased
+                assert_eq!(ParachainStaking::proxy_nonce(staker.account_id), nonce + 1);
+            })
+        }
+
     mod fails_when {
         use super::*;
 


### PR DESCRIPTION
This PR fixes a bug for nominate and bond_extra where rounding issues will attempt to nominate/bond more than what the user intended.

It also contains a small update to the default value of `min_user_stake` and fixes benchmark values.