### PR TITLE
SYS-3007 fix benchmark value on signed_nominate

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1141,8 +1141,7 @@ pub mod pallet {
         }
 
         #[pallet::weight(<T as Config>::WeightInfo::signed_nominate(
-            (T::MaxNominationsPerNominator::get() + T::MaxBottomNominationsPerCandidate::get()) * T::MinSelectedCandidates::get(),
-            T::MaxNominationsPerNominator::get())
+            T::MaxNominationsPerNominator::get(), T::MaxTopNominationsPerCandidate::get())
         )]
         #[transactional]
         pub fn signed_nominate(


### PR DESCRIPTION
This PR fixes a bug where calling `signed_nominate` was exhausting the block weight.