### PR TITLE
SYS-2850 Makes avn-proxy transactional compatible

### DIFF
--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -81,7 +81,15 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        CallDispatched { relayer: T::AccountId, hash: T::Hash },
+        CallDispatched {
+            relayer: T::AccountId,
+            hash: T::Hash,
+        },
+        InnerCallFailedDispatch {
+            relayer: T::AccountId,
+            hash: T::Hash,
+            dispatch_error: DispatchError,
+        },
     }
 
     #[pallet::error]
@@ -126,8 +134,19 @@ pub mod pallet {
             let call_hash: T::Hash = T::Hashing::hash_of(&call);
             let sender: T::Origin = frame_system::RawOrigin::Signed(proof.signer.clone()).into();
 
-            call.dispatch(sender).map(|_| ()).map_err(|e| e.error)?;
-            Self::deposit_event(Event::<T>::CallDispatched { relayer, hash: call_hash });
+            let dispatch_result = call.dispatch(sender).map(|_| ()).map_err(|e| e.error);
+            match dispatch_result {
+                Ok(_) => {
+                    Self::deposit_event(Event::<T>::CallDispatched { relayer, hash: call_hash });
+                },
+                Err(dispatch_error) => {
+                    Self::deposit_event(Event::<T>::InnerCallFailedDispatch {
+                        relayer,
+                        hash: call_hash,
+                        dispatch_error,
+                    });
+                },
+            }
 
             Ok(Some(final_weight).into())
         }

--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -81,15 +81,8 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        CallDispatched {
-            relayer: T::AccountId,
-            hash: T::Hash,
-        },
-        InnerCallFailed {
-            relayer: T::AccountId,
-            hash: T::Hash,
-            dispatch_error: DispatchError,
-        },
+        CallDispatched { relayer: T::AccountId, hash: T::Hash },
+        InnerCallFailed { relayer: T::AccountId, hash: T::Hash, dispatch_error: DispatchError },
     }
 
     #[pallet::error]

--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
             relayer: T::AccountId,
             hash: T::Hash,
         },
-        InnerCallFailedDispatch {
+        InnerCallDispatchFailed {
             relayer: T::AccountId,
             hash: T::Hash,
             dispatch_error: DispatchError,
@@ -140,7 +140,7 @@ pub mod pallet {
                     Self::deposit_event(Event::<T>::CallDispatched { relayer, hash: call_hash });
                 },
                 Err(dispatch_error) => {
-                    Self::deposit_event(Event::<T>::InnerCallFailedDispatch {
+                    Self::deposit_event(Event::<T>::InnerCallDispatchFailed {
                         relayer,
                         hash: call_hash,
                         dispatch_error,

--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
             relayer: T::AccountId,
             hash: T::Hash,
         },
-        InnerCallDispatchFailed {
+        InnerCallFailed {
             relayer: T::AccountId,
             hash: T::Hash,
             dispatch_error: DispatchError,
@@ -140,7 +140,7 @@ pub mod pallet {
                     Self::deposit_event(Event::<T>::CallDispatched { relayer, hash: call_hash });
                 },
                 Err(dispatch_error) => {
-                    Self::deposit_event(Event::<T>::InnerCallDispatchFailed {
+                    Self::deposit_event(Event::<T>::InnerCallFailed {
                         relayer,
                         hash: call_hash,
                         dispatch_error,

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -298,11 +298,7 @@ pub fn proxy_failed_inner_dispatch_event_emitted(
     call_hash: <TestRuntime as system::Config>::Hash,
 ) -> bool {
     return System::events().iter().any(|a| match a.event {
-        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallFailed {
-            relayer,
-            hash,
-            ..
-        }) =>
+        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallFailed { relayer, hash, .. }) =>
             if relayer == call_relayer && call_hash == hash {
                 return true
             } else {

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -303,8 +303,8 @@ pub fn proxy_failed_inner_dispatch_event_emitted(
             hash,
             ..
         }) =>
-        if relayer == call_relayer && call_hash == hash {
-            return true
+            if relayer == call_relayer && call_hash == hash {
+                return true
             } else {
                 return false
             },

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -298,7 +298,7 @@ pub fn proxy_failed_inner_dispatch_event_emitted(
     call_hash: <TestRuntime as system::Config>::Hash,
 ) -> bool {
     return System::events().iter().any(|a| match a.event {
-        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallFailedDispatch {
+        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallDispatchFailed {
             relayer,
             hash,
             ..

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -298,7 +298,7 @@ pub fn proxy_failed_inner_dispatch_event_emitted(
     call_hash: <TestRuntime as system::Config>::Hash,
 ) -> bool {
     return System::events().iter().any(|a| match a.event {
-        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallDispatchFailed {
+        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallFailed {
             relayer,
             hash,
             ..

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -293,7 +293,7 @@ pub fn proxy_event_emitted(
     })
 }
 
-pub fn proxy_failed_inner_dispatch_event_emitted(
+pub fn inner_call_failed_event_emitted(
     call_relayer: AccountId,
     call_hash: <TestRuntime as system::Config>::Hash,
 ) -> bool {

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -293,6 +293,25 @@ pub fn proxy_event_emitted(
     })
 }
 
+pub fn proxy_failed_inner_dispatch_event_emitted(
+    call_relayer: AccountId,
+    call_hash: <TestRuntime as system::Config>::Hash,
+) -> bool {
+    return System::events().iter().any(|a| match a.event {
+        Event::AvnProxy(crate::Event::<TestRuntime>::InnerCallFailedDispatch {
+            relayer,
+            hash,
+            ..
+        }) =>
+        if relayer == call_relayer && call_hash == hash {
+            return true
+            } else {
+                return false
+            },
+        _ => false,
+    })
+}
+
 #[derive(Clone)]
 pub struct SingleNftContext {
     pub unique_external_ref: Vec<u8>,

--- a/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
@@ -74,10 +74,7 @@ mod proxy_without_fees {
 
                 assert_eq!(
                     true,
-                    inner_call_failed_event_emitted(
-                        context.relayer.account_id(),
-                        call_hash
-                    )
+                    inner_call_failed_event_emitted(context.relayer.account_id(), call_hash)
                 );
             })
         }

--- a/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
@@ -74,7 +74,7 @@ mod proxy_without_fees {
 
                 assert_eq!(
                     true,
-                    proxy_failed_inner_dispatch_event_emitted(
+                    inner_call_failed_event_emitted(
                         context.relayer.account_id(),
                         call_hash
                     )

--- a/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_no_fees.rs
@@ -4,7 +4,6 @@
 use crate::{mock::*, *};
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
-use pallet_nft_manager::Error as NftManagerError;
 use sp_runtime::traits::Hash;
 
 mod proxy_without_fees {
@@ -45,6 +44,41 @@ mod proxy_without_fees {
                     None
                 ));
                 assert_eq!(true, single_nft_minted_events_emitted());
+            })
+        }
+
+        #[test]
+        fn inner_call_fails_to_execute() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let context: ProxyContext = Default::default();
+                let inner_call = create_signed_mint_single_nft_call(&context);
+
+                assert_eq!(false, single_nft_minted_events_emitted());
+                assert_ok!(AvnProxy::proxy(
+                    Origin::signed(context.relayer.account_id()),
+                    inner_call,
+                    None
+                ));
+                assert_eq!(single_nft_minted_events_count(), 1);
+
+                let inner_call_with_duplicate_external_ref =
+                    create_signed_mint_single_nft_call(&context);
+                let call_hash = Hashing::hash_of(&inner_call_with_duplicate_external_ref);
+
+                assert_ok!(AvnProxy::proxy(
+                    Origin::signed(context.relayer.account_id()),
+                    inner_call_with_duplicate_external_ref,
+                    None
+                ));
+
+                assert_eq!(
+                    true,
+                    proxy_failed_inner_dispatch_event_emitted(
+                        context.relayer.account_id(),
+                        call_hash
+                    )
+                );
             })
         }
     }
@@ -122,35 +156,6 @@ mod proxy_without_fees {
                 );
 
                 assert_eq!(System::events().len(), 0);
-            })
-        }
-
-        #[test]
-        fn inner_call_fails_to_execute() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context: ProxyContext = Default::default();
-                let inner_call = create_signed_mint_single_nft_call(&context);
-
-                assert_eq!(false, single_nft_minted_events_emitted());
-                assert_ok!(AvnProxy::proxy(
-                    Origin::signed(context.relayer.account_id()),
-                    inner_call,
-                    None
-                ));
-                assert_eq!(single_nft_minted_events_count(), 1);
-
-                let inner_call_with_duplicate_external_ref =
-                    create_signed_mint_single_nft_call(&context);
-
-                assert_noop!(
-                    AvnProxy::proxy(
-                        Origin::signed(context.relayer.account_id()),
-                        inner_call_with_duplicate_external_ref,
-                        None
-                    ),
-                    NftManagerError::<TestRuntime>::ExternalRefIsAlreadyInUse
-                );
             })
         }
     }

--- a/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
@@ -2,9 +2,8 @@
 
 #![cfg(test)]
 use crate::{mock::*, *};
-use frame_support::{assert_err, assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok};
 use pallet_balances::Error as BalanceError;
-use pallet_nft_manager::Error as NftManagerError;
 use sp_runtime::traits::Hash;
 
 pub const GATEWAY_FEE: u128 = ONE_AVT;
@@ -120,16 +119,19 @@ mod charging_fees {
                 let relayer_balance = Balances::free_balance(context.relayer.account_id());
 
                 // Dispatch fails
-                assert_err!(
-                    AvnProxy::proxy(
-                        Origin::signed(context.relayer.account_id()),
-                        inner_call,
-                        payment_authorisation
-                    ),
-                    NftManagerError::<TestRuntime>::ExternalRefIsMandatory
-                );
+                assert_ok!(AvnProxy::proxy(
+                    Origin::signed(context.relayer.account_id()),
+                    inner_call,
+                    payment_authorisation
+                ));
 
-                // No success events emitted
+                assert_eq!(
+                    true,
+                    proxy_failed_inner_dispatch_event_emitted(
+                        context.relayer.account_id(),
+                        call_hash
+                    )
+                );
                 assert_eq!(false, proxy_event_emitted(context.relayer.account_id(), call_hash));
                 assert_eq!(false, single_nft_minted_events_emitted());
 

--- a/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
@@ -127,7 +127,7 @@ mod charging_fees {
 
                 assert_eq!(
                     true,
-                    proxy_failed_inner_dispatch_event_emitted(
+                    inner_call_failed_event_emitted(
                         context.relayer.account_id(),
                         call_hash
                     )

--- a/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
@@ -127,10 +127,7 @@ mod charging_fees {
 
                 assert_eq!(
                     true,
-                    inner_call_failed_event_emitted(
-                        context.relayer.account_id(),
-                        call_hash
-                    )
+                    inner_call_failed_event_emitted(context.relayer.account_id(), call_hash)
                 );
                 assert_eq!(false, proxy_event_emitted(context.relayer.account_id(), call_hash));
                 assert_eq!(false, single_nft_minted_events_emitted());

--- a/pallets/parachain-staking/src/tests/bond_extra_tests.rs
+++ b/pallets/parachain-staking/src/tests/bond_extra_tests.rs
@@ -6,11 +6,13 @@ use crate::{
     assert_event_emitted, assert_last_event, encode_signed_bond_extra_params,
     encode_signed_candidate_bond_extra_params,
     mock::{
-        build_proof, sign, AccountId, AvnProxy, Call as MockCall, Event as MetaEvent, ExtBuilder,
-        MinNominationPerCollator, Origin, ParachainStaking, Signature, Staker, Test, TestAccount,
+        build_proof, inner_call_failed_event_emitted, sign, AccountId, AvnProxy, Call as MockCall,
+        Event as MetaEvent, ExtBuilder, MinNominationPerCollator, Origin, ParachainStaking,
+        Signature, Staker, Test, TestAccount,
     },
     Config, Error, Event, Proof,
 };
+
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
 
@@ -288,9 +290,16 @@ mod proxy_signed_bond_extra {
                     let bond_extra_call =
                         create_call_for_bond_extra(&staker, bad_nonce, amount_to_topup);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), bond_extra_call, None),
-                        Error::<Test>::UnauthorizedSignedBondExtraTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedBondExtraTransaction.into()
+                        )
                     );
                 });
         }
@@ -322,9 +331,14 @@ mod proxy_signed_bond_extra {
                     let bond_extra_call =
                         create_call_for_bond_extra_from_proof(proof, bad_amount_to_topup);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), bond_extra_call, None),
-                        Error::<Test>::NominationBelowMin
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::NominationBelowMin.into())
                     );
                 });
         }
@@ -357,9 +371,17 @@ mod proxy_signed_bond_extra {
                     let bond_extra_call =
                         create_call_for_bond_extra_from_proof(proof, bad_amount_to_topup);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), bond_extra_call, None),
-                        Error::<Test>::UnauthorizedSignedBondExtraTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedBondExtraTransaction.into()
+                        )
                     );
                 });
         }
@@ -397,9 +419,14 @@ mod proxy_signed_bond_extra {
                     let bond_extra_call =
                         create_call_for_bond_extra(&staker, nonce, bad_amount_to_stake);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), bond_extra_call, None),
-                        Error::<Test>::InsufficientBalance
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::InsufficientBalance.into())
                     );
                 });
         }
@@ -434,9 +461,14 @@ mod proxy_signed_bond_extra {
                     let bond_extra_call =
                         create_call_for_bond_extra(&staker, nonce, bad_stake_amount);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), bond_extra_call, None),
-                        Error::<Test>::NominationBelowMin
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::NominationBelowMin.into())
                     );
                 });
         }
@@ -621,9 +653,16 @@ mod proxy_signed_candidate_bond_extra {
                         amount_to_topup,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), bond_extra_call, None),
-                        Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction.into()
+                        )
                     );
                 });
         }
@@ -658,9 +697,16 @@ mod proxy_signed_candidate_bond_extra {
                     let bond_extra_call =
                         create_call_for_candidate_bond_extra_from_proof(proof, bad_amount_to_topup);
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), bond_extra_call, None),
-                        Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction.into()
+                        )
                     );
                 });
         }
@@ -698,9 +744,14 @@ mod proxy_signed_candidate_bond_extra {
                         bad_amount_to_stake,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), bond_extra_call, None),
-                        Error::<Test>::InsufficientBalance
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        bond_extra_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::InsufficientBalance.into())
                     );
                 });
         }

--- a/pallets/parachain-staking/src/tests/mock.rs
+++ b/pallets/parachain-staking/src/tests/mock.rs
@@ -40,7 +40,7 @@ use sp_io;
 use sp_runtime::{
     testing::{Header, UintAuthorityId},
     traits::{BlakeTwo256, ConvertInto, IdentityLookup, SignedExtension, Verify},
-    Perbill, SaturatedConversion,
+    DispatchError, Perbill, SaturatedConversion,
 };
 
 pub type AccountId = <Signature as Verify>::Signer;
@@ -400,6 +400,18 @@ impl InnerCallValidator for TestAvnProxyConfig {
             _ => false,
         }
     }
+}
+
+pub fn inner_call_failed_event_emitted(call_dispatch_error: DispatchError) -> bool {
+    return System::events().iter().any(|a| match a.event {
+        Event::AvnProxy(avn_proxy::Event::<Test>::InnerCallFailed { dispatch_error, .. }) =>
+            if dispatch_error == call_dispatch_error {
+                return true
+            } else {
+                return false
+            },
+        _ => false,
+    })
 }
 
 pub fn build_proof(

--- a/pallets/parachain-staking/src/tests/nominate_tests.rs
+++ b/pallets/parachain-staking/src/tests/nominate_tests.rs
@@ -5,8 +5,9 @@
 use crate::{
     assert_event_emitted, assert_last_event, encode_signed_nominate_params,
     mock::{
-        build_proof, sign, AccountId, AvnProxy, Call as MockCall, Event as MetaEvent, ExtBuilder,
-        Origin, ParachainStaking, Signature, Staker, Test, TestAccount,
+        build_proof, inner_call_failed_event_emitted, sign, AccountId, AvnProxy, Call as MockCall,
+        Event as MetaEvent, ExtBuilder, Origin, ParachainStaking, Signature, Staker, Test,
+        TestAccount,
     },
     Config, Error, Event, NominatorAdded, Proof, StaticLookup,
 };
@@ -281,9 +282,16 @@ mod proxy_signed_nominate {
                         amount_to_stake,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None),
-                        Error::<Test>::UnauthorizedSignedNominateTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        nominate_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedNominateTransaction.into()
+                        )
                     );
                 });
         }
@@ -317,9 +325,16 @@ mod proxy_signed_nominate {
                         vec![collator_1, collator_2],
                         bad_amount_to_stake,
                     );
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None),
-                        Error::<Test>::NominatorBondBelowMin
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        nominate_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::NominatorBondBelowMin.into()
+                        )
                     );
                 });
         }
@@ -350,9 +365,16 @@ mod proxy_signed_nominate {
                     );
                     let nominate_call =
                         create_call_for_nominate_from_proof(proof, bad_targets, amount_to_stake);
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None),
-                        Error::<Test>::UnauthorizedSignedNominateTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        nominate_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedNominateTransaction.into()
+                        )
                     );
                 });
         }
@@ -386,9 +408,14 @@ mod proxy_signed_nominate {
                         bad_amount_to_stake,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None),
-                        Error::<Test>::InsufficientBalance
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        nominate_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::InsufficientBalance.into())
                     );
                 });
         }
@@ -424,9 +451,16 @@ mod proxy_signed_nominate {
                         bad_stake_amount,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), nominate_call, None),
-                        Error::<Test>::NominatorBondBelowMin
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        nominate_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::NominatorBondBelowMin.into()
+                        )
                     );
                 });
         }

--- a/pallets/parachain-staking/src/tests/schedule_revoke_nomination_tests.rs
+++ b/pallets/parachain-staking/src/tests/schedule_revoke_nomination_tests.rs
@@ -7,9 +7,9 @@ use crate::{
     encode_signed_schedule_leave_nominators_params,
     encode_signed_schedule_revoke_nomination_params,
     mock::{
-        build_proof, roll_to, roll_to_era_begin, sign, AccountId, AvnProxy, Balances,
-        Call as MockCall, Event as MetaEvent, ExtBuilder, Origin, ParachainStaking, Signature,
-        Staker, Test, TestAccount,
+        build_proof, inner_call_failed_event_emitted, roll_to, roll_to_era_begin, sign, AccountId,
+        AvnProxy, Balances, Call as MockCall, Event as MetaEvent, ExtBuilder, Origin,
+        ParachainStaking, Signature, Staker, Test, TestAccount,
     },
     Config, Error, Event, Proof,
 };
@@ -394,13 +394,17 @@ mod proxy_signed_schedule_leave_nominators {
                     let leave_nominators_call =
                         create_call_for_signed_schedule_leave_nominators(&staker, bad_nonce);
 
-                    assert_noop!(
-                        AvnProxy::proxy(
-                            Origin::signed(staker.relayer),
-                            leave_nominators_call,
-                            None
-                        ),
-                        Error::<Test>::UnauthorizedSignedScheduleLeaveNominatorsTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        leave_nominators_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedScheduleLeaveNominatorsTransaction
+                                .into()
+                        )
                     );
                 });
         }
@@ -605,13 +609,17 @@ mod proxy_signed_execute_revoke_all_nomination {
                             &staker.account_id,
                         );
 
-                    assert_noop!(
-                        AvnProxy::proxy(
-                            Origin::signed(staker.relayer),
-                            execute_leave_nominators_call,
-                            None
-                        ),
-                        Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        execute_leave_nominators_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
+                                .into()
+                        )
                     );
                 });
         }
@@ -656,13 +664,14 @@ mod proxy_signed_execute_revoke_all_nomination {
                             &bad_nominator,
                         );
 
-                    assert_noop!(
-                        AvnProxy::proxy(
-                            Origin::signed(staker.relayer),
-                            execute_leave_nominators_call,
-                            None
-                        ),
-                        Error::<Test>::NominatorDNE
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        execute_leave_nominators_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::NominatorDNE.into())
                     );
                 });
         }
@@ -706,13 +715,17 @@ mod proxy_signed_execute_revoke_all_nomination {
                             &collator_1,
                         );
 
-                    assert_noop!(
-                        AvnProxy::proxy(
-                            Origin::signed(staker.relayer),
-                            execute_leave_nominators_call,
-                            None
-                        ),
-                        Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        execute_leave_nominators_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
+                                .into()
+                        )
                     );
                 });
         }

--- a/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
+++ b/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
@@ -7,9 +7,9 @@ use crate::{
     encode_signed_execute_nomination_request_params,
     encode_signed_schedule_candidate_unbond_params, encode_signed_schedule_nominator_unbond_params,
     mock::{
-        build_proof, roll_to, roll_to_era_begin, sign, AccountId, AvnProxy, Call as MockCall,
-        Event as MetaEvent, ExtBuilder, MinNominationPerCollator, Origin, ParachainStaking,
-        Signature, Staker, System, Test, TestAccount,
+        build_proof, inner_call_failed_event_emitted, roll_to, roll_to_era_begin, sign, AccountId,
+        AvnProxy, Call as MockCall, Event as MetaEvent, ExtBuilder, MinNominationPerCollator,
+        Origin, ParachainStaking, Signature, Staker, System, Test, TestAccount,
     },
     Bond, Config, Error, Event, NominationAction, Proof, ScheduledRequest,
 };
@@ -273,9 +273,12 @@ mod proxy_signed_schedule_nominator_unbond {
                         amount_to_withdraw,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None),
-                        Error::<Test>::UnauthorizedSignedUnbondTransaction
+                    assert_ok!(AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedUnbondTransaction.into()
+                        )
                     );
                 });
         }
@@ -313,9 +316,12 @@ mod proxy_signed_schedule_nominator_unbond {
                         proof,
                         bad_amount_to_withdraw,
                     );
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None),
-                        Error::<Test>::UnauthorizedSignedUnbondTransaction
+                    assert_ok!(AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedUnbondTransaction.into()
+                        )
                     );
                 });
         }
@@ -353,9 +359,12 @@ mod proxy_signed_schedule_nominator_unbond {
                         bad_amount_to_unbond,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None),
-                        Error::<Test>::NominatorBondBelowMin
+                    assert_ok!(AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::NominatorBondBelowMin.into()
+                        )
                     );
                 });
         }
@@ -392,9 +401,10 @@ mod proxy_signed_schedule_nominator_unbond {
                         bad_amount_to_unbond,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None),
-                        Error::<Test>::NominationBelowMin
+                    assert_ok!(AvnProxy::proxy(Origin::signed(staker.relayer), unbond_call, None));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(Error::<Test>::NominationBelowMin.into())
                     );
                 });
         }
@@ -556,9 +566,16 @@ mod proxy_signed_schedule_collator_unbond {
                         bad_nonce,
                         amount_to_withdraw,
                     );
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), unbond_call, None),
-                        Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        unbond_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction.into()
+                        )
                     );
                 });
         }
@@ -590,9 +607,16 @@ mod proxy_signed_schedule_collator_unbond {
                         proof,
                         bad_amount_to_withdraw,
                     );
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), unbond_call, None),
-                        Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        unbond_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction.into()
+                        )
                     );
                 });
         }
@@ -623,9 +647,16 @@ mod proxy_signed_schedule_collator_unbond {
                         amount_to_withdraw,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(collator_1.relayer), unbond_call, None),
-                        Error::<Test>::CandidateBondBelowMin
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(collator_1.relayer),
+                        unbond_call,
+                        None
+                    ));
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::CandidateBondBelowMin.into()
+                        )
                     );
                 });
         }
@@ -831,9 +862,17 @@ mod signed_execute_nomination_request {
                         staker.account_id,
                     );
 
-                    assert_noop!(
-                        AvnProxy::proxy(Origin::signed(staker.relayer), execute_unbond_call, None),
-                        Error::<Test>::UnauthorizedSignedExecuteNominationRequestTransaction
+                    assert_ok!(AvnProxy::proxy(
+                        Origin::signed(staker.relayer),
+                        execute_unbond_call,
+                        None
+                    ),);
+                    assert_eq!(
+                        true,
+                        inner_call_failed_event_emitted(
+                            Error::<Test>::UnauthorizedSignedExecuteNominationRequestTransaction
+                                .into()
+                        )
                     );
                 });
         }


### PR DESCRIPTION
This PR reafactors avn-proxy pallet to be compatible with v0.9.28 or newer versions of substrate that make all extrinsics transactional.
Up to now, if an error occurred and the extrinsic got rejected, storage changes up to that point were persistent. Avn-proxy pallet was using this functionality to give the fees to the relayer account, when the inner call failed to complete.
In order to persist that behaviour, this PR makes changes on the interface and the behaviour of the system.
Proxied extrinsics that the inner call fails to execute for any reason will be accepted and an `InnerCallFailed` event will be emitted, with the original dispatch error. Fee charges will be persistent in storage.

If the proxied extrinsic fails validation, the behaviour remains the same as it was prior to this PR.

The PR also updates all test that were expecting the proxied extrinsic to fail if the inner call fails. Instead now we look for the event and the appropriate extrinsic info.