### PR TITLE
SYS-3285 Update payment nonce handling - HOTFIX (DO NOT MERGE)

### DIFF
--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -119,16 +119,18 @@ pub mod pallet {
                     .saturating_add(call.get_dispatch_info().weight)
                     .saturating_add(50_000);
 
-                    // Always try to charge a fee, regardless of the outcome of execution.
-                    // If the payment signature is not valid, the nonce is not incremented and the transaction is rejected
-                    // This allows to keep the payment nonce in memory when sending multiple transactions back to back.
-                    Self::charge_fee(&proof, *payment_info)?;
+                // Always try to charge a fee, regardless of the outcome of execution.
+                // If the payment signature is not valid, the nonce is not incremented and the
+                // transaction is rejected This allows to keep the payment nonce in
+                // memory when sending multiple transactions back to back.
+                Self::charge_fee(&proof, *payment_info)?;
             }
 
             // No errors are allowed past this point, otherwise we will undo the payment.
             let call_hash: T::Hash = T::Hashing::hash_of(&call);
 
-            // If the inner call signature does not validate, there is no need to dispatch the tx so return early.
+            // If the inner call signature does not validate, there is no need to dispatch the tx so
+            // return early.
             let inner_call_validation_result = Self::validate_inner_call_signature(&call);
             if let Err(err) = inner_call_validation_result {
                 Self::deposit_event(Event::<T>::InnerCallFailed {
@@ -137,8 +139,9 @@ pub mod pallet {
                     dispatch_error: err,
                 });
 
-                // Return an OK even if the signature is bad. The `InnerCallFailed` event will inform the caller about the failure
-                return Ok(Some(final_weight).into());
+                // Return an OK even if the signature is bad. The `InnerCallFailed` event will
+                // inform the caller about the failure
+                return Ok(Some(final_weight).into())
             }
 
             let sender: T::Origin = frame_system::RawOrigin::Signed(proof.signer.clone()).into();

--- a/pallets/avn-proxy/src/lib.rs
+++ b/pallets/avn-proxy/src/lib.rs
@@ -118,13 +118,29 @@ pub mod pallet {
                 final_weight = T::WeightInfo::charge_fee()
                     .saturating_add(call.get_dispatch_info().weight)
                     .saturating_add(50_000);
-                // If the inner call signature does not validate, exit without charging the sender a
-                // fee
-                Self::validate_inner_call_signature(&call)?;
-                Self::charge_fee(&proof, *payment_info)?;
+
+                    // Always try to charge a fee, regardless of the outcome of execution.
+                    // If the payment signature is not valid, the nonce is not incremented and the transaction is rejected
+                    // This allows to keep the payment nonce in memory when sending multiple transactions back to back.
+                    Self::charge_fee(&proof, *payment_info)?;
             }
 
+            // No errors are allowed past this point, otherwise we will undo the payment.
             let call_hash: T::Hash = T::Hashing::hash_of(&call);
+
+            // If the inner call signature does not validate, there is no need to dispatch the tx so return early.
+            let inner_call_validation_result = Self::validate_inner_call_signature(&call);
+            if let Err(err) = inner_call_validation_result {
+                Self::deposit_event(Event::<T>::InnerCallFailed {
+                    relayer,
+                    hash: call_hash,
+                    dispatch_error: err,
+                });
+
+                // Return an OK even if the signature is bad. The `InnerCallFailed` event will inform the caller about the failure
+                return Ok(Some(final_weight).into());
+            }
+
             let sender: T::Origin = frame_system::RawOrigin::Signed(proof.signer.clone()).into();
 
             let dispatch_result = call.dispatch(sender).map(|_| ()).map_err(|e| e.error);
@@ -205,7 +221,6 @@ impl<T: Config> Pallet<T> {
             ExistenceRequirement::KeepAlive,
         )?;
 
-        // Only increment the nonce if the charge goes through
         <PaymentNonces<T>>::mutate(&payment_info.payer, |n| *n += 1);
 
         Ok(())

--- a/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
+++ b/pallets/avn-proxy/src/tests/proxy_tests_with_fees.rs
@@ -217,13 +217,11 @@ mod charging_fees {
                 let signer_nonce = AvnProxy::payment_nonces(context.signer.account_id());
                 let relayer_balance = Balances::free_balance(context.relayer.account_id());
 
-                assert_ok!(
-                    AvnProxy::proxy(
-                        Origin::signed(context.relayer.account_id()),
-                        inner_call,
-                        Some(Box::new(payment_authorisation))
-                    )
-                );
+                assert_ok!(AvnProxy::proxy(
+                    Origin::signed(context.relayer.account_id()),
+                    inner_call,
+                    Some(Box::new(payment_authorisation))
+                ));
 
                 // Check that fee has been paid by the signer
                 assert_eq!(
@@ -237,8 +235,6 @@ mod charging_fees {
 
                 // Check that payment nonce has increased
                 assert_eq!(AvnProxy::payment_nonces(context.signer.account_id()), signer_nonce + 1);
-
-
             })
         }
     }

--- a/pallets/parachain-staking/src/tests/bond_extra_tests.rs
+++ b/pallets/parachain-staking/src/tests/bond_extra_tests.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     Config, Error, Event, Proof,
 };
-
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
+use pallet_avn_proxy::Error as avn_proxy_error;
 
 fn to_acc_id(id: u64) -> AccountId {
     return TestAccount::new(id).account_id()
@@ -298,7 +298,7 @@ mod proxy_signed_bond_extra {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedBondExtraTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -380,7 +380,7 @@ mod proxy_signed_bond_extra {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedBondExtraTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -661,7 +661,7 @@ mod proxy_signed_candidate_bond_extra {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -705,7 +705,7 @@ mod proxy_signed_candidate_bond_extra {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedCandidateBondExtraTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });

--- a/pallets/parachain-staking/src/tests/nominate_tests.rs
+++ b/pallets/parachain-staking/src/tests/nominate_tests.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::{self as system, RawOrigin};
+use pallet_avn_proxy::Error as avn_proxy_error;
 use sp_runtime::traits::Zero;
 
 fn to_acc_id(id: u64) -> AccountId {
@@ -290,7 +291,7 @@ mod proxy_signed_nominate {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedNominateTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -373,7 +374,7 @@ mod proxy_signed_nominate {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedNominateTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });

--- a/pallets/parachain-staking/src/tests/schedule_revoke_nomination_tests.rs
+++ b/pallets/parachain-staking/src/tests/schedule_revoke_nomination_tests.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
+use pallet_avn_proxy::Error as avn_proxy_error;
 use sp_runtime::traits::Zero;
 use std::cell::RefCell;
 
@@ -402,8 +403,7 @@ mod proxy_signed_schedule_leave_nominators {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedScheduleLeaveNominatorsTransaction
-                                .into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -617,8 +617,7 @@ mod proxy_signed_execute_revoke_all_nomination {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
-                                .into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -723,8 +722,7 @@ mod proxy_signed_execute_revoke_all_nomination {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedExecuteLeaveNominatorsTransaction
-                                .into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });

--- a/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
+++ b/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
+use pallet_avn_proxy::Error as avn_proxy_error;
 use std::cell::RefCell;
 
 thread_local! {
@@ -277,7 +278,7 @@ mod proxy_signed_schedule_nominator_unbond {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedUnbondTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -320,7 +321,7 @@ mod proxy_signed_schedule_nominator_unbond {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedUnbondTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -574,7 +575,7 @@ mod proxy_signed_schedule_collator_unbond {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -615,7 +616,7 @@ mod proxy_signed_schedule_collator_unbond {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedCandidateUnbondTransaction.into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });
@@ -870,8 +871,7 @@ mod signed_execute_nomination_request {
                     assert_eq!(
                         true,
                         inner_call_failed_event_emitted(
-                            Error::<Test>::UnauthorizedSignedExecuteNominationRequestTransaction
-                                .into()
+                            avn_proxy_error::<Test>::UnauthorizedProxyTransaction.into()
                         )
                     );
                 });


### PR DESCRIPTION
This branch is based on v1.0.5 **not** main, hence the conflicts.  

This PR allows for the fee to be charged even if the inner call signature is invalid. 

If the payer has signed (agreed to pay) the inner call signature (the inner call proof), even if that proof is invalid, the payer will be charged and the payment nonce will be incremented
If the payment signature itself is not valid: 
 - the payer will not be charged
 - the payment nonce is not incremented
 - the inner call is not dispatched
