### PR TITLE
Aligns confirmation generation for adding collator

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -206,6 +206,8 @@ impl<T: Config> Pallet<T> {
         let mut url = String::from("eth/sign/");
         url.push_str(data_to_sign);
 
+        info!(target: "avn-service", "avn-service sign request (ecdsa) for data {:?}", data_to_sign);
+
         let ecdsa_signature_utf8 = Self::get_data_from_service(url)?;
         let ecdsa_signature_bytes = core::str::from_utf8(&ecdsa_signature_utf8)
             .map_err(|_| Error::<T>::ErrorConvertingUtf8)?;

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -206,7 +206,7 @@ impl<T: Config> Pallet<T> {
         let mut url = String::from("eth/sign/");
         url.push_str(data_to_sign);
 
-        info!(target: "avn-service", "avn-service sign request (ecdsa) for data {:?}", data_to_sign);
+        info!(target: "avn-service", "avn-service sign request (ecdsa) for hex-encoded data {:?}", data_to_sign);
 
         let ecdsa_signature_utf8 = Self::get_data_from_service(url)?;
         let ecdsa_signature_bytes = core::str::from_utf8(&ecdsa_signature_utf8)

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -40,7 +40,6 @@ impl EthTransactionType {
             EthTransactionType::DeregisterValidator(d) => Ok(d.to_abi()),
             EthTransactionType::SlashValidator(d) => Ok(d.to_abi()),
             EthTransactionType::ActivateCollator(d) => Ok(d.to_abi()),
-            EthTransactionType::ActivateValidator(_d) => Err(EthAbiError::InvalidData),
             _ => Err(EthAbiError::InvalidData),
         }
     }
@@ -323,6 +322,19 @@ impl EthAbiHelper {
 
     pub fn generate_eth_abi_encoding_for_params_only(call: &EthTransactionDescription) -> Vec<u8> {
         return ethabi::encode(&call.call_values)
+    }
+
+    pub fn generate_confirmation_data_for_compacted_calls(
+        keccak_256_hash: &[u8; 32],
+        transaction_id: TransactionId,
+        from: &[u8; 32],
+    ) -> Vec<u8> {
+        let call_values: Vec<Token> = vec![
+            Token::FixedBytes(keccak_256_hash.to_vec()),
+            Token::Uint(EthAbiHelper::u256_to_big_endian(&U256::from(transaction_id)).into()),
+            Token::FixedBytes(from.to_vec()),
+        ];
+        return ethabi::encode(&call_values)
     }
 
     pub fn generate_ethereum_transaction_abi(

--- a/pallets/ethereum-transactions/src/lib.rs
+++ b/pallets/ethereum-transactions/src/lib.rs
@@ -450,7 +450,6 @@ impl<T: Config> Pallet<T> {
             EthTransactionType::PublishRoot(_) => Some(Self::get_publish_root_contract()),
             EthTransactionType::DeregisterValidator(_) |
             EthTransactionType::SlashValidator(_) |
-            EthTransactionType::ActivateValidator(_) |
             EthTransactionType::ActivateCollator(_) =>
                 Some(T::ValidatorManagerContractAddress::get()),
             _ => None,

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -347,10 +347,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_none(origin)?;
 
-            let eth_encoded_data =
-                Self::convert_collator_registration_action_to_confirmation_signing_data(
-                    &action_id, false,
-                )?;
+            let eth_encoded_data = Self::abi_encode_collator_registration_data(&action_id, false)?;
             if !AVN::<T>::eth_signature_is_valid(eth_encoded_data, &validator, &approval_signature)
             {
                 create_and_report_validators_offence::<T>(
@@ -478,12 +475,9 @@ pub mod pallet {
 
                 let voting_session = Self::get_voting_session(action_id);
                 let eth_encoded_data =
-                    Self::convert_collator_registration_action_to_confirmation_signing_data(
-                        action_id, false,
-                    )
-                    .map_err(|_| {
-                        InvalidTransaction::Custom(ERROR_CODE_INVALID_DEREGISTERED_VALIDATOR)
-                    })?;
+                    Self::abi_encode_collator_registration_data(action_id, false).map_err(
+                        |_| InvalidTransaction::Custom(ERROR_CODE_INVALID_DEREGISTERED_VALIDATOR),
+                    )?;
                 return approve_vote_validate_unsigned::<T>(
                     &voting_session,
                     validator,
@@ -594,7 +588,7 @@ const NAME: &'static [u8; 17] = b"validatorsManager";
 
 // Error codes returned by validate unsigned methods
 const ERROR_CODE_INVALID_DEREGISTERED_VALIDATOR: u8 = 10;
-const PACKED_ARGUMENTS_SIZE: usize = 96;
+const PACKED_KEYS_SIZE: usize = 96;
 
 pub type AVN<T> = avn::Pallet<T>;
 
@@ -609,9 +603,7 @@ impl<T: Config> Pallet<T> {
     pub fn sign_validators_action_for_ethereum(
         action_id: &ActionId<T::AccountId>,
     ) -> Result<(String, ecdsa::Signature), DispatchError> {
-        let data = Self::convert_collator_registration_action_to_confirmation_signing_data(
-            action_id, true,
-        )?;
+        let data = Self::abi_encode_collator_registration_data(action_id, true)?;
         return Ok((data.clone(), AVN::<T>::request_ecdsa_signature_from_external_service(&data)?))
     }
 
@@ -630,27 +622,46 @@ impl<T: Config> Pallet<T> {
         Ok(hex::encode(EthAbiHelper::generate_eth_abi_encoding_for_params_only(&eth_description)))
     }
 
-    /// This function generates the data needed to generate a confirmation for registering a new
-    /// collator. The implementation must match this schema:
+    fn concat_and_hash_activation_data(
+        activate_collator_data: &ActivateCollatorData,
+        enable_data_logs: bool,
+    ) -> [u8; 32] {
+        let mut activate_collator_params_concat: [u8; PACKED_KEYS_SIZE] = [0u8; PACKED_KEYS_SIZE];
+
+        activate_collator_params_concat[0..64]
+            .copy_from_slice(&activate_collator_data.t1_public_key.as_bytes()[0..64]);
+        activate_collator_params_concat[64..PACKED_KEYS_SIZE]
+            .copy_from_slice(&activate_collator_data.t2_public_key[0..32]);
+
+        let activate_collator_hash = keccak_256(&activate_collator_params_concat);
+
+        if enable_data_logs {
+            log::info!(
+                "🗜️ Creating packed hash for {:?} transaction: Concat params data (hex encoded): {:?} - keccak_256 hash (hex encoded): {:?}",
+                    &activate_collator_data,
+                    hex::encode(activate_collator_params_concat),
+                    hex::encode(activate_collator_hash)
+            );
+        }
+        return activate_collator_hash
+    }
+
+    /// This function generates the data needed to generate a confirmation for registering a
+    /// newactivate_collator_params_concat collator. The implementation must match this schema:
     /// https://github.com/Aventus-Network-Services/avn-bridge/blob/v1.1.0/contracts/AVNBridge.sol#L344-L345
-    pub fn convert_collator_registration_action_to_confirmation_signing_data(
+    pub fn abi_encode_collator_registration_data(
         action_id: &ActionId<T::AccountId>,
         enable_data_logs: bool,
     ) -> Result<String, DispatchError> {
         let validators_action_data = Self::try_get_validators_action_data(action_id)?;
-        let mut activate_collator_params_concat: [u8; PACKED_ARGUMENTS_SIZE] = [0u8; 96];
 
         let activate_collator_params = match validators_action_data.reserved_eth_transaction {
             EthTransactionType::ActivateCollator(ref d) => d,
             _ => Err(Error::<T>::ErrorGeneratingEthDescription)?,
         };
 
-        activate_collator_params_concat[0..64]
-            .copy_from_slice(&activate_collator_params.t1_public_key.as_bytes()[0..64]);
-        activate_collator_params_concat[64..96]
-            .copy_from_slice(&activate_collator_params.t2_public_key[0..32]);
-
-        let activate_collator_hash = keccak_256(&activate_collator_params_concat);
+        let activate_collator_hash =
+            Self::concat_and_hash_activation_data(activate_collator_params, true);
 
         let sender =
             T::AccountToBytesConvert::into_bytes(&validators_action_data.primary_validator);
@@ -665,16 +676,10 @@ impl<T: Config> Pallet<T> {
 
         if enable_data_logs {
             log::info!(
-                "🗜️ Creating packed hash for {:?} transaction: Concat params data (hex encoded): {:?} - keccak_256 hash (hex encoded): {:?}",
-                    &validators_action_data.reserved_eth_transaction,
-                    hex::encode(activate_collator_params_concat),
-                    hex::encode(activate_collator_hash)
-            );
-            log::info!(
-                "📩 Data used for abi encode: (hash: {:?}, tx_id: {:?}, from: {:?}). Output: {:?}",
-                activate_collator_hash,
+                "📩 Data used for abi encode: (hex-encoded hash: {:?}, tx_id: {:?}, hex-encoded sender: {:?}). Output: {:?}",
+                hex::encode(activate_collator_hash),
                 validators_action_data.eth_transaction_id,
-                &sender,
+                hex::encode(&sender),
                 &hex_encoded_confirmation_data
             );
         }

--- a/pallets/validators-manager/src/vote.rs
+++ b/pallets/validators-manager/src/vote.rs
@@ -159,6 +159,11 @@ pub fn cast_votes_if_required<T: Config>(
                 ActionId::new(action_validator_id, ingress_counter)
             })
             .collect();
+    log::debug!(
+        "📨 Actions to vote upon {:?}, from {:?}",
+        pending_actions_ids.len(),
+        <ValidatorsManager<T> as Store>::PendingApprovals::iter().count()
+    );
 
     // try to send 1 of MAX_VOTING_SESSIONS_RETURNED votes
     for action_id in pending_actions_ids {
@@ -249,6 +254,16 @@ fn action_can_be_voted_on<T: Config>(
     // time the vote gets mined. It may be outside the voting window and get rejected.
     let voting_session = ValidatorsManager::<T>::get_voting_session(action_id);
     let voting_session_data = voting_session.state();
+    log::debug!(
+        "📨 voting_session data: {:#?} - voting_session_data are OK: {:?} \
+        - voting session active: {:?} - voting session is valid: {:?} - vote already in pool: {:?}",
+        voting_session_data,
+        voting_session_data.is_ok(),
+        voting_session.is_active(),
+        voting_session.is_valid(),
+        is_vote_in_transaction_pool::<T>(action_id)
+    );
+
     return voting_session_data.is_ok() &&
         !voting_session_data.expect("voting session data is ok").has_voted(voter) &&
         voting_session.is_active() &&


### PR DESCRIPTION
Reimplements the code that calculates the confirmations

Adds helper function that creates confirmations for calls that have their
arguments concatenated and hashed via keccak 256.

Uses the function above, to calculate confirmations for activate
collator, matching the expected values in avn-bridge.

Adds logs capturing the data generated and hashed.

Related JIRA items:
- SYS-3360
- SYS-3387