### PR TITLE
SYS-3333: Update and fix unit tests - Part 2

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -252,7 +252,8 @@ impl<T: Config> Pallet<T> {
         match T::EthereumPublicKeyChecker::get_validator_for_eth_public_key(
             &recovered_public_key.expect("Checked for error"),
         ) {
-            Some(maybe_validator) => maybe_validator == validator.account_id,
+            Some(maybe_validator) => {
+                maybe_validator == validator.account_id},
             _ => false,
         }
     }

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -252,8 +252,7 @@ impl<T: Config> Pallet<T> {
         match T::EthereumPublicKeyChecker::get_validator_for_eth_public_key(
             &recovered_public_key.expect("Checked for error"),
         ) {
-            Some(maybe_validator) => {
-                maybe_validator == validator.account_id},
+            Some(maybe_validator) => maybe_validator == validator.account_id,
             _ => false,
         }
     }

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -645,7 +645,7 @@ impl<T: Config> Pallet<T> {
 
         let deregister_collator_hash = keccak_256(&deregister_collator_params_concat);
 
-        log::debug!(
+        log::info!(
             "🗜️ Creating packed hash for {:?} transaction: Concat params data (hex encoded): {:?} - keccak_256 hash (hex encoded): {:?}",
                 &deregister_collator_data,
                 hex::encode(deregister_collator_params_concat),
@@ -677,7 +677,7 @@ impl<T: Config> Pallet<T> {
                 &sender,
             ));
 
-        log::debug!(
+        log::info!(
             "📩 Data used for abi encode: (hex-encoded hash: {:?}, tx_id: {:?}, hex-encoded sender: {:?}). Output: {:?}",
             hex::encode(action_parameters_concat_hash),
             validators_action_data.eth_transaction_id,

--- a/pallets/validators-manager/src/mock.rs
+++ b/pallets/validators-manager/src/mock.rs
@@ -467,8 +467,6 @@ thread_local! {
 
     static MOCK_TX_ID: RefCell<TransactionId> = RefCell::new(INITIAL_TRANSACTION_ID);
 
-    pub static ETH_PUBLIC_KEY_VALID: RefCell<bool> = RefCell::new(true);
-
     pub static OFFENCES: RefCell<Vec<(Vec<AccountId>, Offence)>> = RefCell::new(vec![]);
 }
 
@@ -494,33 +492,32 @@ impl ValidatorRegistrationNotifier<ValidatorId> for TestRuntime {
     fn on_validator_registration(_validator_id: &ValidatorId) {}
 }
 
+// Derived from [1u8;32] private key
+pub(crate) const COLLATOR_1_ETHEREUM_PUPLIC_KEY: [u8; 33] =
+    hex!["031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"];
+// Derived from [2u8;32] private key
+pub(crate) const COLLATOR_2_ETHEREUM_PUPLIC_KEY: [u8; 33] =
+    hex!["024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766"];
+// Derived from [3u8;32] private key
+
+pub(crate) const COLLATOR_3_ETHEREUM_PUPLIC_KEY: [u8; 33] =
+    hex!["02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337"];
+// Derived from [4u8;32] private key
+
+pub(crate) const COLLATOR_4_ETHEREUM_PUPLIC_KEY: [u8; 33] =
+    hex!["03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b"];
+// Derived from [5u8;32] private key
+
+pub(crate) const COLLATOR_5_ETHEREUM_PUPLIC_KEY: [u8; 33] =
+    hex!["0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7"];
+
 fn initial_validators_public_keys() -> Vec<ecdsa::Public> {
     return vec![
-        // Derived from [1u8;32] private key
-        Public::from_slice(&hex![
-            "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
-        ])
-        .unwrap(),
-        // Derived from [2u8;32] private key
-        Public::from_slice(&hex![
-            "024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766"
-        ])
-        .unwrap(),
-        // Derived from [3u8;32] private key
-        Public::from_slice(&hex![
-            "02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337"
-        ])
-        .unwrap(),
-        // Derived from [4u8;32] private key
-        Public::from_slice(&hex![
-            "03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b"
-        ])
-        .unwrap(),
-        // Derived from [5u8;32] private key
-        Public::from_slice(&hex![
-            "0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7"
-        ])
-        .unwrap(),
+        Public::from_slice(&COLLATOR_1_ETHEREUM_PUPLIC_KEY).unwrap(),
+        Public::from_slice(&COLLATOR_2_ETHEREUM_PUPLIC_KEY).unwrap(),
+        Public::from_slice(&COLLATOR_3_ETHEREUM_PUPLIC_KEY).unwrap(),
+        Public::from_slice(&COLLATOR_4_ETHEREUM_PUPLIC_KEY).unwrap(),
+        Public::from_slice(&COLLATOR_5_ETHEREUM_PUPLIC_KEY).unwrap(),
     ]
 }
 

--- a/pallets/validators-manager/src/mock.rs
+++ b/pallets/validators-manager/src/mock.rs
@@ -7,7 +7,6 @@ use frame_support::{
     traits::{Currency, GenesisBuild, OnFinalize, OnInitialize},
     BasicExternalities, PalletId,
 };
-use hex::FromHex;
 use hex_literal::hex;
 use pallet_balances as balances;
 use pallet_parachain_staking::{self as parachain_staking};
@@ -69,13 +68,6 @@ pub fn genesis_config_initial_validators() -> [AccountId; 5] {
 }
 pub const REGISTERING_VALIDATOR_TIER1_ID: u128 = 200;
 pub const EXISTENTIAL_DEPOSIT: u64 = 0;
-
-const MOCK_ETH_PUBLIC_KEY: &str =
-    "026f39ae48cacc934a04e0ee8b8e34d5d17ef4d85f93951c32ae15c91ea3b48a7d";
-const MOCK_T2_PUBLIC_KEY_BYTES: [u8; 32] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 209, 170, 222, 173,
-    151, 4, 182,
-];
 
 pub type Extrinsic = TestXt<RuntimeCall, ()>;
 pub type BlockNumber = <TestRuntime as system::Config>::BlockNumber;
@@ -364,36 +356,12 @@ parameter_types! {
 
 impl CandidateTransactionSubmitter<AccountId> for TestRuntime {
     fn submit_candidate_transaction_to_tier1(
-        candidate_type: EthTransactionType,
+        _candidate_type: EthTransactionType,
         _tx_id: TransactionId,
-        submitter: AccountId,
+        _submitter: AccountId,
         _signatures: Vec<ecdsa::Signature>,
     ) -> DispatchResult {
-        let collator_eth_public_key = ecdsa::Public::from_raw(hex!(
-            "02407b0d9f41148bbe3b6c7d4a62585ae66cc32a707441197fa5453abfebd31d57"
-        ));
-        let decompressed_collator_eth_public_key =
-            decompress_eth_public_key(collator_eth_public_key).unwrap();
-        let validator_t2_pub_key_used_in_unit_tests: [u8; 32] =
-            <mock::TestRuntime as Config>::AccountToBytesConvert::into_bytes(&validator_id_3());
-        let validator_t2_pub_key_used_in_benchmarks: [u8; 32] = MOCK_T2_PUBLIC_KEY_BYTES;
-
-        if submitter == get_registered_validator_id() ||
-            candidate_type ==
-                EthTransactionType::DeregisterCollator(DeregisterCollatorData::new(
-                    decompressed_collator_eth_public_key,
-                    validator_t2_pub_key_used_in_unit_tests,
-                )) ||
-            candidate_type ==
-                EthTransactionType::DeregisterCollator(DeregisterCollatorData::new(
-                    decompressed_collator_eth_public_key,
-                    validator_t2_pub_key_used_in_benchmarks,
-                ))
-        {
-            return Ok(())
-        }
-
-        Err(Error::<TestRuntime>::ErrorSubmitCandidateTxnToTier1.into())
+        Ok(())
     }
 
     fn reserve_transaction_id(
@@ -484,11 +452,6 @@ impl FinalisedBlockChecker<BlockNumber> for TestRuntime {
 type IdentificationTuple = (AccountId, AccountId);
 type Offence = crate::ValidatorOffence<IdentificationTuple>;
 
-pub fn get_registered_validator_id() -> AccountId {
-    let topic_receiver = &MockData::get_validator_token_topics()[3];
-    return TestAccount::from_bytes(topic_receiver.as_slice()).account_id()
-}
-
 pub const INITIAL_TRANSACTION_ID: TransactionId = 0;
 
 thread_local! {
@@ -523,15 +486,8 @@ impl EthereumPublicKeyChecker<AccountId> for TestRuntime {
         if !<ValidatorManager as Store>::EthereumPublicKeys::contains_key(eth_public_key) {
             return None
         }
-
         return Some(<ValidatorManager as Store>::EthereumPublicKeys::get(eth_public_key).unwrap())
     }
-}
-
-pub fn set_mock_recovered_account_id(account_id: AccountId) {
-    let eth_public_key =
-        sp_core::ecdsa::Public::from_raw(<[u8; 33]>::from_hex(MOCK_ETH_PUBLIC_KEY).unwrap());
-    <ValidatorManager as Store>::EthereumPublicKeys::insert(eth_public_key, account_id);
 }
 
 impl ValidatorRegistrationNotifier<ValidatorId> for TestRuntime {
@@ -540,24 +496,29 @@ impl ValidatorRegistrationNotifier<ValidatorId> for TestRuntime {
 
 fn initial_validators_public_keys() -> Vec<ecdsa::Public> {
     return vec![
+        // Derived from [1u8;32] private key
         Public::from_slice(&hex![
-            "03471b4c1012dddf4d494c506a098c7b1b719b20bbb177b1174f2166f953c29503"
+            "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
         ])
         .unwrap(),
+        // Derived from [2u8;32] private key
         Public::from_slice(&hex![
-            "0292a73ad9488b934fd04cb31a0f50634841f7105a5b4a8538e4bfa06aa477bed6"
+            "024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766"
         ])
         .unwrap(),
+        // Derived from [3u8;32] private key
         Public::from_slice(&hex![
-            "03c5527886d8e09ad1fededd3231f890685d2d5345385d54181269f80c8926ff8e"
+            "02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337"
         ])
         .unwrap(),
+        // Derived from [4u8;32] private key
         Public::from_slice(&hex![
-            "020e7593c534411f6f0e2fb91340751ada34ee5986f70b300443be17844416b28b"
+            "03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b"
         ])
         .unwrap(),
+        // Derived from [5u8;32] private key
         Public::from_slice(&hex![
-            "02fde5665a2cb42863fb312fb527f2b02110997fc6865df583ca4324be137b7894"
+            "0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7"
         ])
         .unwrap(),
     ]
@@ -593,6 +554,7 @@ impl ExtBuilder {
         ext
     }
 
+    /// Setups a genesis configuration with 5 collators to the genesis state
     pub fn with_validators(mut self) -> Self {
         let validator_account_ids: &Vec<AccountId> =
             &VALIDATORS.with(|l| l.borrow().clone().unwrap());


### PR DESCRIPTION
This commit aligns the unit tests with the new implementation. It includes the following updates and fixes:

- Updates the mocks to use valid ECDSA signatures as confirmations.
- Modifies the test accounts to be derived from test private keys with a pattern of [1u8;32].
- Corrects internal logic in the tests that previously used the same AuthorityID for all validators.
- Removes tests that were specifically designed to test a mock implementation.

This PR rectifies any failing tests in #165 
