### PR TITLE
SYS-3347 fix benchmark tests

### DIFF
--- a/pallets/avn-transaction-payment/src/benchmarking.rs
+++ b/pallets/avn-transaction-payment/src/benchmarking.rs
@@ -64,6 +64,6 @@ benchmarks! {
 
 impl_benchmark_test_suite!(
     Pallet,
-    crate::mock::ExtBuilder::build_default().as_externality(),
+    crate::mock::new_test_ext(),
     crate::mock::TestRuntime,
 );

--- a/pallets/avn-transaction-payment/src/benchmarking.rs
+++ b/pallets/avn-transaction-payment/src/benchmarking.rs
@@ -62,8 +62,4 @@ benchmarks! {
     }
 }
 
-impl_benchmark_test_suite!(
-    Pallet,
-    crate::mock::new_test_ext(),
-    crate::mock::TestRuntime,
-);
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::TestRuntime,);


### PR DESCRIPTION
This PR fixes a bug when running benchmark tests. 

![image](https://github.com/Aventus-Network-Services/avn-parachain/assets/39748285/c04ad16a-e2a8-485c-af2c-dc04968eaaae)

