### PR TITLE
SYS-3338: Convert ValidatorAccountIds to Bounded Vector

### DIFF
--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -47,7 +47,7 @@ use sp_avn_common::{
     calculate_two_third_quorum, eth_key_actions::decompress_eth_public_key, event_types::Validator,
     safe_add_block_numbers, IngressCounter,
 };
-use sp_core::{ecdsa, H512};
+use sp_core::{ecdsa, H512, ConstU32};
 
 pub use pallet_parachain_staking::{self as parachain_staking, BalanceOf, PositiveImbalanceOf};
 use pallet_session::historical::IdentificationTuple;
@@ -174,7 +174,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn validator_account_ids)]
     pub type ValidatorAccountIds<T: Config> =
-        StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAXIMUM_VALIDATORS_BOUND>>>;
+        StorageValue<_, BoundedVec<T::AccountId, MaximumValidatorsBound>>;
 
     #[pallet::storage]
     pub type ValidatorActions<T: Config> = StorageDoubleMap<
@@ -588,7 +588,7 @@ const MAX_OFFENDERS: u32 = 2;
 // TODO [TYPE: review][PRI: medium]: if needed, make this the default value to a configurable
 // option. See MinimumValidatorCount in Staking pallet as a reference
 const DEFAULT_MINIMUM_VALIDATORS_COUNT: usize = 2;
-const MAXIMUM_VALIDATORS_BOUND: u32 = 256;
+type MaximumValidatorsBound = ConstU32<256>;
 
 const NAME: &'static [u8; 17] = b"validatorsManager";
 

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -257,6 +257,7 @@ pub mod pallet {
             ensure_root(origin)?;
             let validator_account_ids =
                 Self::validator_account_ids().ok_or(Error::<T>::NoValidators)?;
+            ensure!(validator_account_ids.len() > 0, Error::<T>::NoValidators);
 
             ensure!(
                 !validator_account_ids.contains(&collator_account_id),

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -47,7 +47,7 @@ use sp_avn_common::{
     calculate_two_third_quorum, eth_key_actions::decompress_eth_public_key, event_types::Validator,
     safe_add_block_numbers, IngressCounter,
 };
-use sp_core::{ecdsa, H512, ConstU32};
+use sp_core::{ecdsa, ConstU32, H512};
 
 pub use pallet_parachain_staking::{self as parachain_staking, BalanceOf, PositiveImbalanceOf};
 use pallet_session::historical::IdentificationTuple;

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -190,7 +190,6 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn get_vote)]
-    #[pallet::unbounded]
     pub type VotesRepository<T: Config> = StorageMap<
         _,
         Blake2_128Concat,

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -66,13 +66,13 @@ use crate::offence::{
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use frame_support::pallet_prelude::*;
+    use frame_support::{assert_ok, pallet_prelude::*};
     use frame_system::pallet_prelude::*;
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
     #[pallet::without_storage_info]
-    // TODO review the above
+    // TODO remove the above.
     pub struct Pallet<T>(_);
 
     #[pallet::config]
@@ -134,6 +134,7 @@ pub mod pallet {
         /// The ethereum public key of this validator alredy exists
         ValidatorEthKeyAlreadyExists,
         ErrorRemovingAccountFromCollators,
+        MaximumValidatorsReached,
     }
 
     #[pallet::event]
@@ -170,14 +171,11 @@ pub mod pallet {
         },
     }
 
-    // TODO: [STATE MIGRATION] - this storage item was changed from returning a default value to
-    // returning an option
     #[pallet::storage]
     #[pallet::getter(fn validator_account_ids)]
-    pub type ValidatorAccountIds<T: Config> = StorageValue<_, Vec<T::AccountId>>;
+    pub type ValidatorAccountIds<T: Config> =
+        StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAXIMUM_VALIDATORS_BOUND>>>;
 
-    // TODO: [STATE MIGRATION] - this storage item was changed from returning a default value to
-    // returning an option
     #[pallet::storage]
     pub type ValidatorActions<T: Config> = StorageDoubleMap<
         _,
@@ -192,6 +190,7 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn get_vote)]
+    #[pallet::unbounded]
     pub type VotesRepository<T: Config> = StorageMap<
         _,
         Blake2_128Concat,
@@ -234,7 +233,7 @@ pub mod pallet {
                 self.validators.len()
             );
             for (validator_account_id, eth_public_key) in &self.validators {
-                <ValidatorAccountIds<T>>::append(validator_account_id);
+                assert_ok!(<ValidatorAccountIds<T>>::try_append(validator_account_id));
                 <EthereumPublicKeys<T>>::insert(eth_public_key, validator_account_id);
             }
         }
@@ -257,8 +256,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             ensure_root(origin)?;
             let validator_account_ids =
-                Self::validator_account_ids().or_else(|| Some(vec![])).expect("empty vec");
-            ensure!(validator_account_ids.len() > 0, Error::<T>::NoValidators);
+                Self::validator_account_ids().ok_or(Error::<T>::NoValidators)?;
 
             ensure!(
                 !validator_account_ids.contains(&collator_account_id),
@@ -283,7 +281,8 @@ pub mod pallet {
 
             Self::register_validator(&collator_account_id, &collator_eth_public_key)?;
 
-            <ValidatorAccountIds<T>>::append(collator_account_id.clone());
+            <ValidatorAccountIds<T>>::try_append(collator_account_id.clone())
+                .map_err(|_| Error::<T>::MaximumValidatorsReached)?;
             <EthereumPublicKeys<T>>::insert(collator_eth_public_key, collator_account_id);
 
             // TODO: benchmark `register_validator` and add to the weight
@@ -588,6 +587,8 @@ const MAX_OFFENDERS: u32 = 2;
 // TODO [TYPE: review][PRI: medium]: if needed, make this the default value to a configurable
 // option. See MinimumValidatorCount in Staking pallet as a reference
 const DEFAULT_MINIMUM_VALIDATORS_COUNT: usize = 2;
+const MAXIMUM_VALIDATORS_BOUND: u32 = 256;
+
 const NAME: &'static [u8; 17] = b"validatorsManager";
 
 // Error codes returned by validate unsigned methods

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -3,7 +3,7 @@
 use crate::{self as validators_manager, *};
 use avn::FinalisedBlockChecker;
 use frame_support::{
-    assert_ok, parameter_types,
+    parameter_types,
     traits::{Currency, GenesisBuild, OnFinalize, OnInitialize},
     BasicExternalities, PalletId,
 };
@@ -720,7 +720,7 @@ impl MockData {
 
 impl ValidatorManager {
     pub fn insert_to_validators(to_insert: &AccountId) {
-        assert_ok!(<ValidatorAccountIds<TestRuntime>>::try_append(to_insert.clone()));
+        <ValidatorAccountIds<TestRuntime>>::try_append(to_insert.clone()).expect("Too many validator accounts in genesis");
     }
 }
 

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -3,7 +3,7 @@
 use crate::{self as validators_manager, *};
 use avn::FinalisedBlockChecker;
 use frame_support::{
-    parameter_types,
+    assert_ok, parameter_types,
     traits::{Currency, GenesisBuild, OnFinalize, OnInitialize},
     BasicExternalities, PalletId,
 };
@@ -680,7 +680,7 @@ impl MockData {
 
 impl ValidatorManager {
     pub fn insert_to_validators(to_insert: &AccountId) {
-        <ValidatorAccountIds<TestRuntime>>::append(to_insert.clone());
+        assert_ok!(<ValidatorAccountIds<TestRuntime>>::try_append(to_insert.clone()));
     }
 }
 

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -720,7 +720,8 @@ impl MockData {
 
 impl ValidatorManager {
     pub fn insert_to_validators(to_insert: &AccountId) {
-        <ValidatorAccountIds<TestRuntime>>::try_append(to_insert.clone()).expect("Too many validator accounts in genesis");
+        <ValidatorAccountIds<TestRuntime>>::try_append(to_insert.clone())
+            .expect("Too many validator accounts in genesis");
     }
 }
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -588,7 +588,9 @@ mod add_validator {
                 let context = &AddValidatorContext::default();
 
                 set_session_keys(&context.collator);
-                <<ValidatorManager as Store>::ValidatorAccountIds>::append(&context.collator);
+                assert_ok!(<<ValidatorManager as Store>::ValidatorAccountIds>::try_append(
+                    &context.collator
+                ));
 
                 assert_noop!(
                     register_validator(&context.collator, &context.collator_eth_public_key),

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -598,5 +598,19 @@ mod add_validator {
                 );
             });
         }
+
+        #[test]
+        fn maximum_collators_is_reached() {
+            let mut ext = ExtBuilder::build_default().with_maximum_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &AddValidatorContext::default();
+
+                set_session_keys(&context.collator);
+                assert_noop!(
+                    register_validator(&context.collator, &context.collator_eth_public_key),
+                    Error::<TestRuntime>::MaximumValidatorsReached
+                );
+            });
+        }
     }
 }


### PR DESCRIPTION
This commit converts the ValidatorAccountIds storage item to a bounded Vector.
The vector is now limited to 256 elements. The necessary adjustments have been
made to the operations that interact with the storage, using the appropriate interfaces.
No storage migration is required for this conversion.
Tests have been updated accordingly to reflect the changes.

