### PR TITLE
SYS-3453: Remove duplicate transfer event and update tests

### DIFF
--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -161,12 +161,6 @@ pub mod pallet {
             token_balance: T::TokenBalance,
             eth_tx_hash: H256,
         },
-        TokenTransferred {
-            token_id: T::TokenId,
-            sender: T::AccountId,
-            recipient: T::AccountId,
-            token_balance: T::TokenBalance,
-        },
         CallDispatched {
             relayer: T::AccountId,
             call_hash: T::Hash,
@@ -315,12 +309,6 @@ pub mod pallet {
 
             Self::settle_transfer(&token_id, &from, &to, &amount)?;
 
-            Self::deposit_event(Event::<T>::TokenTransferred {
-                token_id,
-                sender: from,
-                recipient: to,
-                token_balance: amount,
-            });
             Ok(())
         }
 

--- a/pallets/token-manager/src/test_non_avt_tokens.rs
+++ b/pallets/token-manager/src/test_non_avt_tokens.rs
@@ -234,14 +234,6 @@ fn avn_test_signed_transfer_with_valid_input_should_succeed() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID_2, recipient_account_id)),
             4 * amount
         );
-
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender: sender_account_id,
-                recipient: recipient_account_id,
-                token_balance: amount
-            })));
     });
 }
 
@@ -317,14 +309,6 @@ fn avn_test_signed_transfer_of_0_token_should_succeed() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID_2, recipient_account_id)),
             4 * amount
         );
-
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender: sender_account_id,
-                recipient: recipient_account_id,
-                token_balance: zero_amount
-            })));
     });
 }
 
@@ -391,14 +375,6 @@ fn avn_test_self_signed_transfer_should_succeed() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID_2, sender_account_id)),
             3 * amount
         );
-
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender: sender_account_id,
-                recipient: recipient_account_id,
-                token_balance: amount
-            })));
     });
 }
 
@@ -466,14 +442,6 @@ fn avn_test_self_signed_transfer_of_0_token_should_succeed() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID_2, sender_account_id)),
             3 * amount
         );
-
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender: sender_account_id,
-                recipient: recipient_account_id,
-                token_balance: zero_amount
-            })));
     });
 }
 

--- a/pallets/token-manager/src/test_proxying_signed_transfer.rs
+++ b/pallets/token-manager/src/test_proxying_signed_transfer.rs
@@ -175,18 +175,11 @@ fn check_proxy_transfer_default_call_succeed(call: Box<<TestRuntime as Config>::
     let call_hash = Hashing::hash_of(&call);
 
     assert_ok!(TokenManager::proxy(RuntimeOrigin::signed(default_relayer()), call));
-    assert_eq!(System::events().len(), 2);
+    assert_eq!(System::events().len(), 1);
     assert!(System::events().iter().any(|a| a.event ==
         RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::CallDispatched {
             relayer: default_relayer(),
             call_hash
-        })));
-    assert!(System::events().iter().any(|a| a.event ==
-        RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-            token_id: NON_AVT_TOKEN_ID,
-            sender: default_sender(),
-            recipient: default_receiver(),
-            token_balance: DEFAULT_AMOUNT
         })));
 }
 
@@ -228,17 +221,6 @@ fn avn_test_proxy_signed_transfer_succeeds() {
             RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::CallDispatched {
                 relayer,
                 call_hash
-            })));
-
-        // In order to validate that the proxied call has been dispatched we need any proof that
-        // transfer was called. In this case we will check that the Transferred signal was
-        // emitted.
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
             })));
     });
 }
@@ -300,17 +282,6 @@ fn avt_proxy_signed_transfer_succeeds() {
                 relayer,
                 call_hash
             })));
-
-        // In order to validate that the proxied call has been dispatched we need any proof that
-        // transfer was called. In this case we will check that the Transferred signal was
-        // emitted.
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
-            })));
     });
 }
 
@@ -342,13 +313,6 @@ fn avn_test_direct_signed_transfer_succeeds() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID, recipient)),
             DEFAULT_AMOUNT
         );
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
-            })));
     });
 }
 
@@ -395,14 +359,6 @@ fn avt_direct_signed_transfer_succeeds() {
 
         // Check that the token manager nonce increases
         assert_eq!(NON_ZERO_NONCE + 1, <TokenManager as Store>::Nonces::get(sender));
-
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
-            })));
     });
 }
 
@@ -444,13 +400,6 @@ fn avn_test_proxy_signed_transfer_succeeds_with_nonce_zero() {
             RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::CallDispatched {
                 relayer,
                 call_hash
-            })));
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
             })));
     });
 }
@@ -936,14 +885,6 @@ fn avn_test_proxy_gas_costs_paid_correctly() {
                 call_hash
             })));
 
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
-            })));
-
         let fee: u128 = (BASE_FEE + TX_LEN as u64) as u128;
         assert_eq!(Balances::free_balance(relayer), AMOUNT_100_TOKEN - fee);
         assert_eq!(Balances::free_balance(sender), 0);
@@ -1005,7 +946,7 @@ fn avn_test_regular_call_gas_costs_paid_correctly() {
         ));
 
         let fee: u128 = (BASE_FEE + TX_LEN as u64) as u128;
-        assert_eq!(System::events().len(), 2);
+        assert_eq!(System::events().len(), 1);
         assert_eq!(Balances::free_balance(sender), AMOUNT_100_TOKEN - fee);
         assert_eq!(
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID, sender)),
@@ -1015,13 +956,6 @@ fn avn_test_regular_call_gas_costs_paid_correctly() {
             <TokenManager as Store>::Balances::get((NON_AVT_TOKEN_ID, recipient)),
             DEFAULT_AMOUNT
         );
-        assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: NON_AVT_TOKEN_ID,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
-            })));
     });
 }
 


### PR DESCRIPTION
Removed the 'TokenTransferred' event from the  token-manager pallet and updated tests accordingly 