### PR TITLE
SYS-3453: Removed duplicate transfer event and updated tests

### DIFF
--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -315,12 +315,6 @@ pub mod pallet {
 
             Self::settle_transfer(&token_id, &from, &to, &amount)?;
 
-            Self::deposit_event(Event::<T>::TokenTransferred {
-                token_id,
-                sender: from,
-                recipient: to,
-                token_balance: amount,
-            });
             Ok(())
         }
 
@@ -475,6 +469,13 @@ impl<T: Config> Pallet<T> {
             <Balances<T>>::mutate((token_id, from), |balance| *balance -= *amount);
 
             <Balances<T>>::mutate((token_id, to), |balance| *balance += *amount);
+
+            Self::deposit_event(Event::<T>::TokenTransferred {
+                token_id: token_id.clone(),
+                sender: from.clone(),
+                recipient: to.clone(),
+                token_balance: amount.clone(),
+            });
         }
 
         <Nonces<T>>::mutate(from, |n| *n += 1);

--- a/pallets/token-manager/src/test_proxying_signed_transfer.rs
+++ b/pallets/token-manager/src/test_proxying_signed_transfer.rs
@@ -305,11 +305,10 @@ fn avt_proxy_signed_transfer_succeeds() {
         // transfer was called. In this case we will check that the Transferred signal was
         // emitted.
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Transfer {
+                from: sender,
+                to: recipient,
+                amount: DEFAULT_AMOUNT
             })));
     });
 }
@@ -397,11 +396,10 @@ fn avt_direct_signed_transfer_succeeds() {
         assert_eq!(NON_ZERO_NONCE + 1, <TokenManager as Store>::Nonces::get(sender));
 
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenTransferred {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender,
-                recipient,
-                token_balance: DEFAULT_AMOUNT
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Transfer {
+                from: sender,
+                to: recipient,
+                amount: DEFAULT_AMOUNT
             })));
     });
 }


### PR DESCRIPTION
Removed duplicate transfer events by refactoring code in lib.rs. Updated tests to test for balances.Transfer instead of token-manager.TokenTransferred when testing AVT transfers.
