### PR TITLE
SYS-3338: Convert Voting to Use Bounded Data Structures

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -101,6 +101,7 @@ pub mod pallet {
         InvalidVote,
         ErrorRecoveringPublicKeyFromSignature,
         InvalidECDSASignature,
+        VectorBoundsExceeded,
     }
 
     #[pallet::storage]

--- a/pallets/summary/Cargo.toml
+++ b/pallets/summary/Cargo.toml
@@ -61,4 +61,5 @@ runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
+    "pallet-ethereum-transactions/runtime-benchmarks",
 ]

--- a/pallets/summary/src/benchmarking.rs
+++ b/pallets/summary/src/benchmarking.rs
@@ -48,7 +48,7 @@ fn setup_voting_session<T: Config>(root_id: &RootId<T::BlockNumber>) -> u32 {
     VotesRepository::<T>::insert(
         root_id,
         VotingSessionData::<T::AccountId, T::BlockNumber>::new(
-            root_id.encode(),
+            root_id.session_id(),
             quorum,
             voting_period_end.expect("already checked"),
             current_block_number,
@@ -86,11 +86,17 @@ fn setup_votes<T: Config>(
                 generate_ecdsa_signature::<T>(validators[i].key.clone(), i as u64);
             match is_approval {
                 true => VotesRepository::<T>::mutate(root_id, |vote| {
-                    vote.ayes.push(validators[i].account_id.clone());
-                    vote.confirmations.push(approval_signature.clone());
+                    vote.ayes
+                        .try_push(validators[i].account_id.clone())
+                        .expect("Failed to add mock aye vote");
+                    vote.confirmations
+                        .try_push(approval_signature.clone())
+                        .expect("Failed to add mock confirmation vote");
                 }),
                 false => VotesRepository::<T>::mutate(root_id, |vote| {
-                    vote.nays.push(validators[i].account_id.clone())
+                    vote.nays
+                        .try_push(validators[i].account_id.clone())
+                        .expect("Failed to add mock nay vote");
                 }),
             }
         }

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -117,7 +117,7 @@ impl Summary {
     ) {
         <<Summary as Store>::VotesRepository>::insert(
             root_id,
-            VotingSessionData::new(root_id.encode(), quorum, voting_period_end, 0),
+            VotingSessionData::new(root_id.session_id(), quorum, voting_period_end, 0),
         );
     }
 
@@ -126,11 +126,15 @@ impl Summary {
     }
 
     pub fn record_approve_vote(root_id: &RootId<BlockNumber>, voter: AccountId) {
-        <<Summary as Store>::VotesRepository>::mutate(root_id, |vote| vote.ayes.push(voter));
+        <<Summary as Store>::VotesRepository>::mutate(root_id, |vote| {
+            vote.ayes.try_push(voter).expect("Failed to record aye vote");
+        });
     }
 
     pub fn record_reject_vote(root_id: &RootId<BlockNumber>, voter: AccountId) {
-        <<Summary as Store>::VotesRepository>::mutate(root_id, |vote| vote.nays.push(voter));
+        <<Summary as Store>::VotesRepository>::mutate(root_id, |vote| {
+            vote.nays.try_push(voter).expect("Failed to record nay vote");
+        });
     }
 
     pub fn set_total_ingresses(ingress_counter: IngressCounter) {
@@ -369,6 +373,8 @@ impl CandidateTransactionSubmitter<AccountId> for TestRuntime {
         });
         return Ok(value)
     }
+    #[cfg(feature = "runtime-benchmarks")]
+    fn set_transaction_id(_candidate_type: &EthTransactionType, _id: TransactionId) {}
 }
 
 /*********************** Add validators support ********************** */

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -815,6 +815,8 @@ pub mod record_summary_calculation {
     use tests_vote::setup_approved_root;
 
     mod succeeds_implies_that {
+        use sp_runtime::BoundedVec;
+
         use super::*;
 
         #[test]
@@ -926,12 +928,12 @@ pub mod record_summary_calculation {
                 assert_eq!(
                     Summary::get_vote(context.root_id),
                     VotingSessionData {
-                        voting_session_id: context.root_id.encode(),
+                        voting_session_id: context.root_id.session_id(),
                         threshold: QUORUM,
-                        ayes: vec![],
-                        nays: vec![],
+                        ayes: BoundedVec::default(),
+                        nays: BoundedVec::default(),
                         end_of_voting_period: VOTING_PERIOD_END,
-                        confirmations: vec![],
+                        confirmations: BoundedVec::default(),
                         created_at_block: 10 // Setup creates block number 10
                     }
                 );

--- a/pallets/validators-manager/src/benchmarking.rs
+++ b/pallets/validators-manager/src/benchmarking.rs
@@ -164,7 +164,7 @@ fn setup_voting_session<T: Config>(action_id: &ActionId<T::AccountId>) -> u32 {
     VotesRepository::<T>::insert(
         action_id,
         VotingSessionData::<T::AccountId, T::BlockNumber>::new(
-            action_id.encode(),
+            action_id.session_id(),
             quorum,
             voting_period_end.expect("already checked"),
             0u32.into(),
@@ -204,11 +204,17 @@ fn setup_votes<T: Config>(
             let approval_signature: ecdsa::Signature = generate_mock_ecdsa_signature::<T>(i as u8);
             match is_approval {
                 true => VotesRepository::<T>::mutate(action_id, |vote| {
-                    vote.ayes.push(validators[i].account_id.clone());
-                    vote.confirmations.push(approval_signature.clone());
+                    vote.ayes
+                        .try_push(validators[i].account_id.clone())
+                        .expect("Failed to add mock aye vote");
+                    vote.confirmations
+                        .try_push(approval_signature.clone())
+                        .expect("Failed to add mock confirmation vote");
                 }),
                 false => VotesRepository::<T>::mutate(action_id, |vote| {
-                    vote.nays.push(validators[i].account_id.clone())
+                    vote.nays
+                        .try_push(validators[i].account_id.clone())
+                        .expect("Failed to add mock nay vote");
                 }),
             }
         }

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -149,7 +149,7 @@ impl ValidatorManager {
     ) {
         <<ValidatorManager as Store>::VotesRepository>::insert(
             action_id,
-            VotingSessionData::new(action_id.encode(), quorum, voting_period_end, 0),
+            VotingSessionData::new(action_id.session_id(), quorum, voting_period_end, 0),
         );
     }
 
@@ -176,13 +176,13 @@ impl ValidatorManager {
 
     pub fn record_approve_vote(action_id: &ActionId<AccountId>, voter: AccountId) {
         <<ValidatorManager as Store>::VotesRepository>::mutate(action_id, |vote| {
-            vote.ayes.push(voter)
+            vote.ayes.try_push(voter).expect("Failed to record aye vote");
         });
     }
 
     pub fn record_reject_vote(action_id: &ActionId<AccountId>, voter: AccountId) {
         <<ValidatorManager as Store>::VotesRepository>::mutate(action_id, |vote| {
-            vote.nays.push(voter)
+            vote.nays.try_push(voter).expect("Failed to record nay vote");
         });
     }
 

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use codec::{Codec, Decode, Encode};
-use sp_core::{crypto::KeyTypeId, ecdsa, H160};
+use sp_core::{crypto::KeyTypeId, ecdsa, ConstU32, H160};
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::keccak_256, EcdsaVerifyError};
 use sp_runtime::{
     scale_info::TypeInfo,
@@ -38,6 +38,10 @@ pub const ETHEREUM_PREFIX: &'static [u8] = b"\x19Ethereum Signed Message:\n32";
 pub const EXTERNAL_SERVICE_PORT_NUMBER_KEY: &'static [u8; 15] = b"avn_port_number";
 /// Default port number the external service runs on.
 pub const DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER: &str = "2020";
+/// Bound used for Vectors containing validators
+pub type MaximumValidatorsBound = ConstU32<256>;
+/// Bound used for voting session IDs
+pub type VotingSessionIdBound = ConstU32<64>;
 
 #[derive(Debug)]
 pub enum ECDSAVerificationError {


### PR DESCRIPTION
This commit converts the Voting mechanism in the summary and validators manager to use Bounded data structures. The changes include:

- Using BoundedVec for votes and confirmations
- Introducing WeakBoundedVec for the voting session ID (to be updated to BoundedVec in a separate change)
- Enabling storage information generation for the summary and validators manager pallets
- Adjusting function interfaces to handle potential failure when adding a vote
- Replacing Infallible paths with WeakBoundedVec as an interim solution
- Updating tests and benchmarks
- Resolving a dependency issue in benchmarks

