### PR TITLE
SYS-3512: move TokenTransferred event call and update tests

### DIFF
--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -478,11 +478,11 @@ impl<T: Config> Pallet<T> {
     }
 
     fn settle_lower(
-        token_id: T::TokenId, 
+        token_id: T::TokenId,
         from: &T::AccountId,
         to: &T::AccountId,
         amount: u128,
-        t1_recipient: H160
+        t1_recipient: H160,
     ) -> DispatchResult {
         if token_id == Self::avt_token_contract().into() {
             let lower_amount = <BalanceOf<T> as TryFrom<u128>>::try_from(amount)

--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -335,15 +335,7 @@ pub mod pallet {
             let to_account_id = T::AccountId::decode(&mut Self::lower_account_id().as_bytes())
                 .map_err(|_| Error::<T>::ErrorConvertingAccountId)?;
 
-            Self::settle_lower(&from, token_id, amount)?;
-
-            Self::deposit_event(Event::<T>::TokenLowered {
-                token_id,
-                sender: from,
-                recipient: to_account_id,
-                amount,
-                t1_recipient,
-            });
+            Self::settle_lower(token_id, &from, &to_account_id, amount, t1_recipient)?;
 
             let final_weight = if token_id == Self::avt_token_contract().into() {
                 <T as pallet::Config>::WeightInfo::lower_avt_token()
@@ -388,15 +380,7 @@ pub mod pallet {
             let to_account_id = T::AccountId::decode(&mut Self::lower_account_id().as_bytes())
                 .map_err(|_| Error::<T>::ErrorConvertingAccountId)?;
 
-            Self::settle_lower(&from, token_id, amount)?;
-
-            Self::deposit_event(Event::<T>::TokenLowered {
-                token_id,
-                sender: from,
-                recipient: to_account_id,
-                amount,
-                t1_recipient,
-            });
+            Self::settle_lower(token_id, &from, &to_account_id, amount, t1_recipient)?;
 
             let final_weight = if token_id == Self::avt_token_contract().into() {
                 <T as pallet::Config>::WeightInfo::signed_lower_avt_token()
@@ -493,7 +477,13 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    fn settle_lower(from: &T::AccountId, token_id: T::TokenId, amount: u128) -> DispatchResult {
+    fn settle_lower(
+        token_id: T::TokenId, 
+        from: &T::AccountId,
+        to: &T::AccountId,
+        amount: u128,
+        t1_recipient: H160
+    ) -> DispatchResult {
         if token_id == Self::avt_token_contract().into() {
             let lower_amount = <BalanceOf<T> as TryFrom<u128>>::try_from(amount)
                 .or_else(|_error| Err(Error::<T>::AmountOverflow))?;
@@ -522,6 +512,14 @@ impl<T: Config> Pallet<T> {
             ensure!(sender_balance >= lower_amount, Error::<T>::InsufficientSenderBalance);
 
             <Balances<T>>::mutate((token_id, from), |balance| *balance -= lower_amount);
+
+            Self::deposit_event(Event::<T>::TokenLowered {
+                token_id,
+                sender: from.clone(),
+                recipient: to.clone(),
+                amount,
+                t1_recipient,
+            });
         }
 
         <Nonces<T>>::mutate(from, |n| *n += 1);

--- a/pallets/token-manager/src/test_avt_tokens.rs
+++ b/pallets/token-manager/src/test_avt_tokens.rs
@@ -164,9 +164,9 @@ fn avn_test_lower_all_avt_token_succeed() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
-                who: from_account_id, 
-                amount: amount
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
+                who: from_account_id,
+                amount
             })));
     });
 }
@@ -193,9 +193,9 @@ fn avn_test_lower_some_avt_token_succeed() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
-                who: from_account_id, 
-                amount: amount 
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
+                who: from_account_id,
+                amount
             })));
     });
 }
@@ -249,9 +249,9 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
-                who: from_account_id, 
-                amount: amount 
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
+                who: from_account_id,
+                amount
             })));
 
         // Lift and lower AVT tokens again
@@ -268,9 +268,9 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
-                who: from_account_id, 
-                amount: amount 
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
+                who: from_account_id,
+                amount
             })));
     });
 }

--- a/pallets/token-manager/src/test_avt_tokens.rs
+++ b/pallets/token-manager/src/test_avt_tokens.rs
@@ -164,12 +164,9 @@ fn avn_test_lower_all_avt_token_succeed() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenLowered {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender: from_account_id,
-                recipient: to_account_id,
-                amount,
-                t1_recipient
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
+                who: from_account_id, 
+                amount: amount
             })));
     });
 }
@@ -196,12 +193,9 @@ fn avn_test_lower_some_avt_token_succeed() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenLowered {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender: from_account_id,
-                recipient: to_account_id,
-                amount,
-                t1_recipient
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
+                who: from_account_id, 
+                amount: amount 
             })));
     });
 }
@@ -255,12 +249,9 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenLowered {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender: from_account_id,
-                recipient: to_account_id,
-                amount,
-                t1_recipient
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
+                who: from_account_id, 
+                amount: amount 
             })));
 
         // Lift and lower AVT tokens again
@@ -277,12 +268,9 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
         ));
         assert_eq!(Balances::free_balance(from_account_id), from_account_balance_before - amount);
         assert!(System::events().iter().any(|a| a.event ==
-            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::TokenLowered {
-                token_id: AVT_TOKEN_CONTRACT,
-                sender: from_account_id,
-                recipient: to_account_id,
-                amount,
-                t1_recipient
+            RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw { 
+                who: from_account_id, 
+                amount: amount 
             })));
     });
 }


### PR DESCRIPTION
Key Changes:
-TokenTransferred event call to only occur if the given token (token_id) is not avt 
-Updated settle_lower function parameters accordingly
-Updated tests accordingly

[SYS-3512](https://aventus-network-services.atlassian.net/browse/SYS-3512l)

[SYS-3512]: https://aventus-network-services.atlassian.net/browse/SYS-3512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ