### PR TITLE
SYS-3338: Convert Voting Session ID to Use Bounded Data Structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.36#cb4f2491b00af7d7817f3a54209c26b20faa1f51"
+dependencies = [
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2031,7 @@ dependencies = [
  "frame-system",
  "hex",
  "hex-literal",
+ "node-primitives",
  "pallet-avn",
  "pallet-ethereum-transactions",
  "pallet-session",

--- a/pallets/avn/src/vote.rs
+++ b/pallets/avn/src/vote.rs
@@ -20,7 +20,7 @@ use sp_runtime::{
     transaction_validity::{
         InvalidTransaction, TransactionPriority, TransactionValidity, ValidTransaction,
     },
-    BoundedVec, WeakBoundedVec,
+    BoundedVec,
 };
 use sp_std::prelude::*;
 
@@ -38,7 +38,7 @@ pub const REJECT_VOTE: bool = false;
 pub struct VotingSessionData<AccountId, BlockNumber> {
     // TODO convert to BoundedVec
     /// The unique identifier for this voting session
-    pub voting_session_id: WeakBoundedVec<u8, VotingSessionIdBound>,
+    pub voting_session_id: BoundedVec<u8, VotingSessionIdBound>,
     /// The number of approval votes that are needed to reach an outcome.
     pub threshold: u32,
     /// The current set of voters that approved it.
@@ -58,7 +58,7 @@ pub struct VotingSessionData<AccountId, BlockNumber> {
 impl<AccountId, BlockNumber: Zero> Default for VotingSessionData<AccountId, BlockNumber> {
     fn default() -> Self {
         Self {
-            voting_session_id: WeakBoundedVec::default(),
+            voting_session_id: BoundedVec::default(),
             threshold: 0u32,
             ayes: BoundedVec::default(),
             nays: BoundedVec::default(),
@@ -71,7 +71,7 @@ impl<AccountId, BlockNumber: Zero> Default for VotingSessionData<AccountId, Bloc
 
 impl<AccountId: Member, BlockNumber: Member> VotingSessionData<AccountId, BlockNumber> {
     pub fn new(
-        session_id: WeakBoundedVec<u8, VotingSessionIdBound>,
+        session_id: BoundedVec<u8, VotingSessionIdBound>,
         threshold: u32,
         end_of_voting_period: BlockNumber,
         created_at_block: BlockNumber,

--- a/pallets/summary/Cargo.toml
+++ b/pallets/summary/Cargo.toml
@@ -34,6 +34,7 @@ frame-benchmarking = {default-features = false, git = "https://github.com/parity
 
 [dev-dependencies]
 substrate-test-utils = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
+node-primitives = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
 parking_lot = { version = "0.12.0" }
 pallet-session = {features = ["historical"], git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 assert_matches = "1.3.0"

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -19,7 +19,7 @@ use sp_runtime::{
         InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
         ValidTransaction,
     },
-    DispatchError, WeakBoundedVec,
+    BoundedVec, DispatchError,
 };
 use sp_std::prelude::*;
 
@@ -1378,8 +1378,8 @@ impl<BlockNumber: AtLeast32Bit + Encode> RootId<BlockNumber> {
         return RootId::<BlockNumber> { range, ingress_counter }
     }
 
-    fn session_id(&self) -> WeakBoundedVec<u8, VotingSessionIdBound> {
-        WeakBoundedVec::force_from(self.encode(), Some("summary pallet action id"))
+    fn session_id(&self) -> BoundedVec<u8, VotingSessionIdBound> {
+        BoundedVec::truncate_from(self.encode())
     }
 }
 

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -1717,3 +1717,19 @@ mod if_process_summary_is_called_a_second_time {
 }
 
 // TODO: add a test to ensure we pick validators in sequential order of their index
+
+mod constrains {
+    use crate::{RootId, RootRange};
+    use node_primitives::BlockNumber;
+    use sp_avn_common::VotingSessionIdBound;
+    use sp_core::Get;
+
+    #[test]
+    fn ensure_action_id_encodes_within_boundaries() {
+        let action_id = RootId::<BlockNumber>::new(RootRange::new(0u32.into(), 60u32.into()), 1);
+        assert!(
+            action_id.session_id().len() as u32 <= VotingSessionIdBound::get(),
+            "The encoded size of RootId must not exceed the VotingSessionIdBound"
+        );
+    }
+}

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -19,7 +19,7 @@ use sp_runtime::{
     scale_info::TypeInfo,
     traits::{Convert, Member},
     transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
-    DispatchError, WeakBoundedVec,
+    DispatchError,
 };
 use sp_std::prelude::*;
 
@@ -1052,8 +1052,8 @@ impl<AccountId: Member + Encode> ActionId<AccountId> {
     fn new(action_account_id: AccountId, ingress_counter: IngressCounter) -> Self {
         return ActionId::<AccountId> { action_account_id, ingress_counter }
     }
-    fn session_id(&self) -> WeakBoundedVec<u8, VotingSessionIdBound> {
-        WeakBoundedVec::force_from(self.encode(), Some("validators manager action id"))
+    fn session_id(&self) -> BoundedVec<u8, VotingSessionIdBound> {
+        BoundedVec::truncate_from(self.encode())
     }
 }
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -614,3 +614,19 @@ mod add_validator {
         }
     }
 }
+
+mod constrains {
+
+    use crate::ActionId;
+    use sp_avn_common::VotingSessionIdBound;
+    use sp_core::{sr25519::Public, Get};
+
+    #[test]
+    fn ensure_action_id_encodes_within_boundaries() {
+        let action_id = ActionId::<Public>::new(Public::from_raw([1u8; 32]), 1);
+        assert!(
+            action_id.session_id().len() as u32 <= VotingSessionIdBound::get(),
+            "The encoded size of ActionId must not exceed the VotingSessionIdBound"
+        );
+    }
+}


### PR DESCRIPTION
Updates the Voting module to use `BoundedVec` instead of `WeakBoundedVec` for voting session IDs. The session IDs are now truncated using the `truncate` function to enforce the bounds of the data structure. It is important to ensure that the encoding of session IDs does not exceed the specified bounds.
To ensure this, tests have been added to verify that the constraints are properly enforced.
