### PR TITLE
SYS-3338 convert nft manager storage to bounded

### DIFF
--- a/pallets/avn/src/vote.rs
+++ b/pallets/avn/src/vote.rs
@@ -12,7 +12,10 @@ use frame_support::{
     ensure,
 };
 use sp_application_crypto::RuntimeAppPublic;
-use sp_avn_common::{event_types::Validator, MaximumValidatorsBound, VotingSessionIdBound};
+use sp_avn_common::{
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    event_types::Validator,
+};
 use sp_core::ecdsa;
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/nft-manager/src/batch_nft.rs
+++ b/pallets/nft-manager/src/batch_nft.rs
@@ -16,12 +16,13 @@
 
 use crate::{
     keccak_256, BatchInfoId, BatchOpenForSale, Config, Decode, DispatchResult, Encode, Error,
-    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftInfo, NftInfoId,
-    NftInfos, NftSaleType, NftUniqueId, Nfts, Pallet, ProcessedEventsChecker, Proof, Royalty, Vec,
-    BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160, U256,
+    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftExternalRefBound,
+    NftInfo, NftInfoId, NftInfos, NftSaleType, NftUniqueId, Nfts, Pallet, ProcessedEventsChecker,
+    Proof, Royalty, Vec, BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160, U256,
 };
 use frame_support::{dispatch::DispatchError, ensure};
 use sp_avn_common::event_types::NftMintData;
+use sp_core::bounded::BoundedVec;
 
 pub const SIGNED_CREATE_BATCH_CONTEXT: &'static [u8] = b"authorization for create batch operation";
 pub const SIGNED_MINT_BATCH_NFT_CONTEXT: &'static [u8] =
@@ -149,12 +150,17 @@ pub fn process_mint_batch_nft_event<T: Config>(
     let owner = T::AccountId::decode(&mut data.t2_owner_public_key.as_bytes())
         .expect("32 bytes will always decode into an AccountId");
 
-    Ok(mint_batch_nft::<T>(data.batch_id, owner, data.sale_index, &data.unique_external_ref)?)
+    Ok(mint_batch_nft::<T>(
+        data.batch_id,
+        owner,
+        data.sale_index,
+        data.unique_external_ref.clone(),
+    )?)
 }
 
 pub fn validate_mint_batch_nft_request<T: Config>(
     batch_id: NftBatchId,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
 ) -> Result<NftInfo<T::AccountId>, DispatchError> {
     ensure!(batch_id.is_zero() == false, Error::<T>::BatchIdIsMandatory);
     ensure!(<BatchInfoId<T>>::contains_key(&batch_id), Error::<T>::BatchDoesNotExist);
@@ -175,13 +181,13 @@ pub fn mint_batch_nft<T: Config>(
     batch_id: NftBatchId,
     owner: T::AccountId,
     sale_index: u64,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
 ) -> DispatchResult {
-    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, unique_external_ref)?;
+    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, &unique_external_ref)?;
     let nft_id = generate_batch_nft_id::<T>(&batch_id, &sale_index);
     ensure!(<Nfts<T>>::contains_key(&nft_id) == false, Error::<T>::NftAlreadyExists);
 
-    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref.to_vec(), owner.clone());
+    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref, owner.clone());
     Pallet::<T>::add_nft_and_update_owner(&owner, &nft);
 
     let mut nfts_for_batch = <NftBatches<T>>::get(batch_id);

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -15,8 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
+use sp_core::bounded::BoundedVec;
 use sp_runtime::traits::Member;
 
+pub(crate) use sp_avn_common::bounds::NftExternalRefBound;
 pub const ROYALTY_RATE_DENOMINATOR: u32 = 1_000_000;
 
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq, MaxEncodedLen, TypeInfo)]
@@ -46,7 +48,7 @@ pub struct Nft<AccountId: Member> {
     /// Id of an info struct instance
     pub info_id: NftInfoId,
     /// Unique reference to the NFT asset stored off-chain
-    pub unique_external_ref: Vec<u8>,
+    pub unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
     /// Transfer nonce of this NFT
     pub nonce: u64,
     /// Owner account address of this NFT
@@ -61,7 +63,7 @@ impl<AccountId: Member> Nft<AccountId> {
     pub fn new(
         nft_id: NftId,
         info_id: NftInfoId,
-        unique_external_ref: Vec<u8>,
+        unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
         owner: AccountId,
     ) -> Self {
         return Nft::<AccountId> {

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -772,8 +772,8 @@ mod signed_mint_batch_nft {
                 let mut context = MintBatchNftContext::default();
                 context.setup();
 
-                let out_of_bounds_size = 4096;
-                context.unique_external_ref = (0..out_of_bounds_size).map(|_| 65).collect();
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
 
                 let index = 0u64;
                 let batch_id = create_batch_and_list();

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -87,13 +87,18 @@ mod cancel_single_nft_listing {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
         }
 
         pub fn cancel_nft_listing_data(&self) -> NftCancelListingData {
             return NftCancelListingData { nft_id: self.nft_id(), op_id: self.op_id }
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -84,9 +84,14 @@ mod open_for_sale {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
@@ -66,7 +66,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
@@ -68,7 +68,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Test string should not exceed bound"),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -132,6 +132,11 @@ impl Context {
                 })
         })
     }
+
+    pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+        BoundedVec::try_from(self.unique_external_ref.clone())
+            .expect("Unique external reference bound was exceeded.")
+    }
 }
 
 mod proxy_signed_mint_single_nft {
@@ -160,7 +165,7 @@ mod proxy_signed_mint_single_nft {
                     Nft::new(
                         context.nft_id,
                         context.info_id,
-                        context.unique_external_ref,
+                        context.bounded_external_ref(),
                         context.nft_owner_account
                     ),
                     <Nfts<TestRuntime>>::get(&context.nft_id).unwrap()
@@ -200,7 +205,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -209,12 +214,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.unique_external_ref)
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -305,7 +310,10 @@ mod proxy_signed_mint_single_nft {
             ext.execute_with(|| {
                 let context = Context::default();
                 context.setup();
-                <UsedExternalReferences<TestRuntime>>::insert(&context.unique_external_ref, true);
+                <UsedExternalReferences<TestRuntime>>::insert(
+                    &context.bounded_external_ref(),
+                    true,
+                );
                 let call = context.create_signed_mint_single_nft_call();
 
                 assert_noop!(
@@ -425,7 +433,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -466,7 +474,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -507,7 +515,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -551,7 +559,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -572,7 +580,7 @@ mod proxy_signed_mint_single_nft {
                 let data_to_sign = (
                     SIGNED_MINT_SINGLE_NFT_CONTEXT,
                     &context.relayer,
-                    &context.unique_external_ref,
+                    &context.bounded_external_ref(),
                     other_royalties,
                     context.t1_authority,
                 );
@@ -597,7 +605,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -640,7 +648,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -669,7 +677,7 @@ mod signed_mint_single_nft {
                     Origin::signed(context.nft_owner_account),
                     proof,
                     context.unique_external_ref.clone(),
-                    context.royalties,
+                    context.royalties.clone(),
                     context.t1_authority
                 ));
 
@@ -678,7 +686,7 @@ mod signed_mint_single_nft {
                     Nft::new(
                         context.nft_id,
                         context.info_id,
-                        context.unique_external_ref,
+                        context.bounded_external_ref(),
                         context.nft_owner_account
                     ),
                     <Nfts<TestRuntime>>::get(&context.nft_id).unwrap()
@@ -723,7 +731,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -738,12 +746,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.unique_external_ref)
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -759,7 +767,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -849,7 +857,10 @@ mod signed_mint_single_nft {
             ext.execute_with(|| {
                 let context = Context::default();
                 context.setup();
-                <UsedExternalReferences<TestRuntime>>::insert(&context.unique_external_ref, true);
+                <UsedExternalReferences<TestRuntime>>::insert(
+                    &context.bounded_external_ref(),
+                    true,
+                );
                 let proof = context.create_signed_mint_single_nft_proof();
 
                 assert_noop!(
@@ -990,7 +1001,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1029,7 +1040,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1068,7 +1079,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1110,7 +1121,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1154,7 +1165,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1195,7 +1206,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());

--- a/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
@@ -74,7 +74,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
@@ -180,8 +180,8 @@ mod mint_single_nft {
                 assert_eq!(false, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
                 assert_eq!(false, context.event_emitted_with_single_nft_minted());
 
-                let out_of_bounds_size = 4096;
-                context.unique_external_ref = (0..out_of_bounds_size).map(|_| 65).collect();
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
 
                 assert_noop!(
                     context.call_mint_single_nft(),

--- a/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
@@ -170,6 +170,28 @@ mod mint_single_nft {
         }
 
         #[test]
+        fn external_ref_is_out_of_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context: Context = Default::default();
+                let expected_info_id: NftInfoId = NftManager::next_info_id();
+
+                assert_eq!(false, <Nfts<TestRuntime>>::contains_key(&context.generate_nft_id()));
+                assert_eq!(false, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+
+                let out_of_bounds_size = 4096;
+                context.unique_external_ref = (0..out_of_bounds_size).map(|_| 65).collect();
+
+                assert_noop!(
+                    context.call_mint_single_nft(),
+                    Error::<TestRuntime>::ExternalRefOutOfBounds
+                );
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+            });
+        }
+
+        #[test]
         fn external_ref_is_taken() {
             let mut ext = ExtBuilder::build_default().as_externality();
             ext.execute_with(|| {

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -91,7 +91,7 @@ mod transfer_eth_nft {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
         }
@@ -116,6 +116,11 @@ mod transfer_eth_nft {
 
         pub fn perform_transfer(&self) -> DispatchResult {
             return NftManager::transfer_eth_nft(&self.event_id, &self.transfer_to_nft_data())
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -7,10 +7,11 @@ use alloc::string::{String, ToString};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::{
+    bounds::VotingSessionIdBound,
     calculate_two_third_quorum,
     event_types::Validator,
     offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
-    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter, VotingSessionIdBound,
+    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter,
 };
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -1721,7 +1721,7 @@ mod if_process_summary_is_called_a_second_time {
 mod constrains {
     use crate::{RootId, RootRange};
     use node_primitives::BlockNumber;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::Get;
 
     #[test]

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -44,8 +44,11 @@ use pallet_ethereum_transactions::{
 };
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
-    calculate_two_third_quorum, eth_key_actions::decompress_eth_public_key, event_types::Validator,
-    safe_add_block_numbers, IngressCounter, MaximumValidatorsBound, VotingSessionIdBound,
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    calculate_two_third_quorum,
+    eth_key_actions::decompress_eth_public_key,
+    event_types::Validator,
+    safe_add_block_numbers, IngressCounter,
 };
 use sp_core::{bounded::BoundedVec, ecdsa, H512};
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -618,7 +618,7 @@ mod add_validator {
 mod constrains {
 
     use crate::ActionId;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::{sr25519::Public, Get};
 
     #[test]

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use codec::{Codec, Decode, Encode};
-use sp_core::{crypto::KeyTypeId, ecdsa, ConstU32, H160};
+use sp_core::{crypto::KeyTypeId, ecdsa, H160};
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::keccak_256, EcdsaVerifyError};
 use sp_runtime::{
     scale_info::TypeInfo,
@@ -38,10 +38,15 @@ pub const ETHEREUM_PREFIX: &'static [u8] = b"\x19Ethereum Signed Message:\n32";
 pub const EXTERNAL_SERVICE_PORT_NUMBER_KEY: &'static [u8; 15] = b"avn_port_number";
 /// Default port number the external service runs on.
 pub const DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER: &str = "2020";
-/// Bound used for Vectors containing validators
-pub type MaximumValidatorsBound = ConstU32<256>;
-/// Bound used for voting session IDs
-pub type VotingSessionIdBound = ConstU32<64>;
+
+pub mod bounds {
+    use sp_core::ConstU32;
+
+    /// Bound used for Vectors containing validators
+    pub type MaximumValidatorsBound = ConstU32<256>;
+    /// Bound used for voting session IDs
+    pub type VotingSessionIdBound = ConstU32<64>;
+}
 
 #[derive(Debug)]
 pub enum ECDSAVerificationError {

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -46,6 +46,8 @@ pub mod bounds {
     pub type MaximumValidatorsBound = ConstU32<256>;
     /// Bound used for voting session IDs
     pub type VotingSessionIdBound = ConstU32<64>;
+    /// Bound used for NFT external references
+    pub type NftExternalRefBound = ConstU32<1024>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Updates the code, tests and Benchmarks to use a bound for external
references in storage.
Move constants into a separate module in avn-common crate.
Adds new tests to test the minting behaviour when the bound is not respected