### PR TITLE
SYS-3338 Converts Royalties and Batches size in bounded data

### DIFF
--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -6,7 +6,7 @@ use frame_system as system;
 use hex_literal::hex;
 use pallet_balances;
 use pallet_nft_manager::nft_data::Royalty;
-use sp_core::{sr25519, Pair, H160, H256};
+use sp_core::{sr25519, ConstU32, Pair, H160, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::{Header, UintAuthorityId},
@@ -113,6 +113,7 @@ impl pallet_nft_manager::Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = ConstU32<10>;
 }
 
 impl pallet_avn::Config for TestRuntime {

--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -71,6 +71,10 @@ fn bounded_unique_external_ref() -> BoundedVec<u8, NftExternalRefBound> {
         .expect("Unique external reference bound was exceeded.")
 }
 
+pub fn bounded_royalties(royalties: Vec<Royalty>) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+    BoundedVec::try_from(royalties.clone()).expect("Royalty bound was exceeded.")
+}
+
 fn get_relayer<T: Config>() -> T::AccountId {
     let relayer_account: H256 =
         H256(hex!("0000000000000000000000000000000000000000000000000000000000000001"));
@@ -348,12 +352,12 @@ struct CreateBatch<T: Config> {
 }
 
 impl<T: Config> CreateBatch<T> {
-    fn new(number_of_royalties: u32) -> Self {
+    fn new(batch_size: u32) -> Self {
         let relayer_account_id = get_relayer::<T>();
         let (creator_key_pair, creator_account_id) = get_user_account::<T>();
 
-        let total_supply = 100;
-        let royalties = Self::setup_royalties(number_of_royalties);
+        let total_supply = batch_size as u64;
+        let royalties = Self::setup_royalties(NftRoyaltiesBound::get());
         let t1_authority = H160(hex!("0000000000000000000000000000000000000001"));
         let nonce = 0u64;
 
@@ -406,7 +410,7 @@ impl<T: Config> CreateBatch<T> {
         create_batch::<T>(
             U256::zero(),
             batch_id,
-            self.royalties.clone(),
+            self.bounded_royalties(),
             self.total_supply,
             self.t1_authority,
             self.creator_account_id.clone(),
@@ -415,6 +419,10 @@ impl<T: Config> CreateBatch<T> {
         <BatchNonces<T>>::mutate(&self.creator_account_id, |n| *n += 1);
 
         return batch_id
+    }
+
+    pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+        bounded_royalties(self.royalties.clone())
     }
 }
 
@@ -435,7 +443,7 @@ impl<T: Config> MintBatchNft<T> {
         let (nft_owner_key_pair, nft_owner_account_id) = get_user_account::<T>();
 
         // create batch and list
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
         <BatchOpenForSale<T>>::insert(batch_id, NftSaleType::Fiat);
 
@@ -506,7 +514,7 @@ impl<T: Config> ListBatch<T> {
 
         let market = NftSaleType::Fiat;
 
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
         let nonce = <BatchNonces<T>>::get(&creator_account_id);
 
@@ -551,7 +559,7 @@ impl<T: Config> EndBatchSale<T> {
 
         let market = NftSaleType::Fiat;
 
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
 
         <BatchOpenForSale<T>>::insert(batch_id, market);
@@ -596,7 +604,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -631,7 +639,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -754,7 +762,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -822,7 +830,7 @@ benchmarks! {
     }
 
     proxy_signed_create_batch {
-        let r in 1 .. MAX_NUMBER_OF_ROYALTIES;
+        let r in 1 .. T::BatchBound::get();
         let batch: CreateBatch<T> = CreateBatch::new(r);
         let call: <T as Config>::RuntimeCall = batch.generate_signed_create_batch();
         let boxed_call: Box<<T as Config>::RuntimeCall> = Box::new(call);

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -41,7 +41,7 @@ impl RoyaltyRate {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct Nft<AccountId: Member> {
     /// Unique identifier of a nft
     pub nft_id: NftId,
@@ -77,14 +77,14 @@ impl<AccountId: Member> Nft<AccountId> {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct NftInfo<AccountId: Member> {
     /// Unique identifier of this information
     pub info_id: NftInfoId,
     /// Batch Id defined by client
     pub batch_id: Option<NftBatchId>,
     /// Royalties payment rate for the nft.
-    pub royalties: Vec<Royalty>,
+    pub royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
     /// Total supply of NFTs in this collection:
     ///  - 1: it is for a singleton
     ///  - >1: it is for a batch
@@ -97,7 +97,11 @@ pub struct NftInfo<AccountId: Member> {
 }
 
 impl<AccountId: Member> NftInfo<AccountId> {
-    pub fn new(info_id: NftInfoId, royalties: Vec<Royalty>, t1_authority: H160) -> Self {
+    pub fn new(
+        info_id: NftInfoId,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
+        t1_authority: H160,
+    ) -> Self {
         return NftInfo::<AccountId> {
             info_id,
             batch_id: None,
@@ -111,7 +115,7 @@ impl<AccountId: Member> NftInfo<AccountId> {
     pub fn new_batch(
         info_id: NftInfoId,
         batch_id: NftBatchId,
-        royalties: Vec<Royalty>,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
         t1_authority: H160,
         total_supply: u64,
         creator: AccountId,

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -84,7 +84,7 @@ mod cancel_single_nft_listing {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -99,6 +99,10 @@ mod cancel_single_nft_listing {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -19,7 +19,7 @@
 use frame_support::parameter_types;
 use frame_system as system;
 use sp_avn_common::event_types::EthEventId;
-use sp_core::{sr25519, Pair, H256};
+use sp_core::{sr25519, ConstU32, Pair, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::Header,
@@ -39,6 +39,7 @@ pub type Hashing = <TestRuntime as system::Config>::Hashing;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
+pub type MockNftBatchBound = ConstU32<8>;
 
 frame_support::construct_runtime!(
     pub enum TestRuntime where
@@ -59,6 +60,7 @@ impl Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = MockNftBatchBound;
 }
 
 parameter_types! {

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -81,7 +81,7 @@ mod open_for_sale {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -92,6 +92,10 @@ mod open_for_sale {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -137,6 +137,10 @@ impl Context {
         BoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
+
+    pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+        BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
+    }
 }
 
 mod proxy_signed_mint_single_nft {
@@ -188,7 +192,11 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&context.info_id));
 
                 assert_eq!(
-                    NftInfo::new(context.info_id, context.royalties, context.t1_authority),
+                    NftInfo::new(
+                        context.info_id,
+                        context.bounded_royalties(),
+                        context.t1_authority
+                    ),
                     <NftInfos<TestRuntime>>::get(&context.info_id).unwrap()
                 );
             });
@@ -707,14 +715,18 @@ mod signed_mint_single_nft {
                 assert_ok!(NftManager::signed_mint_single_nft(
                     Origin::signed(context.nft_owner_account),
                     proof,
-                    context.unique_external_ref,
+                    context.unique_external_ref.clone(),
                     context.royalties.clone(),
                     context.t1_authority
                 ));
 
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&context.info_id));
                 assert_eq!(
-                    NftInfo::new(context.info_id, context.royalties, context.t1_authority),
+                    NftInfo::new(
+                        context.info_id,
+                        context.bounded_royalties(),
+                        context.t1_authority
+                    ),
                     <NftInfos<TestRuntime>>::get(&context.info_id).unwrap()
                 );
             });

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -88,7 +88,7 @@ mod transfer_eth_nft {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -121,6 +121,10 @@ mod transfer_eth_nft {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 


### PR DESCRIPTION
Converts the code to use bounded data for Royalties and Batches. Updates tests, adds new ones that test the boundaries and updates benchmarks code.
Removes older migration code as all chains have been migrated and there is no value converting the old data struct.
