### PR TITLE
SYS-3338 Adds migration for external reference

### DIFF
--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -150,7 +150,7 @@ impl<T: Config> MintSingleNft<T> {
     fn setup(self) -> Self {
         <Nfts<T>>::remove(&self.nft_id);
         <NftInfos<T>>::remove(&self.nft_id);
-        <UsedExternalReferences<T>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<T>>::remove(&self.weak_bounded_external_ref());
         return self
     }
 
@@ -164,6 +164,11 @@ impl<T: Config> MintSingleNft<T> {
             t1_authority: self.t1_authority,
         }
         .into()
+    }
+
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
+            .expect("Unique external reference bound was exceeded.")
     }
 }
 
@@ -481,6 +486,11 @@ impl<T: Config> MintBatchNft<T> {
         }
     }
 
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
+            .expect("Unique external reference bound was exceeded.")
+    }
+
     fn generate_signed_mint_batch_nft(
         &self,
         batch_id: U256,
@@ -607,8 +617,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -642,8 +652,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -765,8 +775,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: mint_nft.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
@@ -868,8 +878,8 @@ benchmarks! {
             Nft::new(context.nft_id, U256::zero(), context.unique_external_ref.clone(), context.nft_owner.clone()),
             Nfts::<T>::get(&context.nft_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(context.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(context.weak_bounded_external_ref()));
 
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: context.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::BatchNftMinted {

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -563,7 +563,7 @@ impl MintBatchNftContext {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
         <UsedExternalReferences<TestRuntime>>::remove(
-            &BoundedVec::try_from(self.unique_external_ref.clone())
+            &WeakBoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded."),
         );
     }
@@ -650,7 +650,7 @@ mod signed_mint_batch_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        BoundedVec::try_from(context.unique_external_ref)
+                        WeakBoundedVec::try_from(context.unique_external_ref)
                             .expect("Unique external reference bound was exceeded.")
                     )
                 );

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
+        <UsedExternalReferences<TestRuntime>>::remove(&self.weak_bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -135,6 +135,11 @@ impl Context {
 
     pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
         BoundedVec::try_from(self.unique_external_ref.clone())
+            .expect("Unique external reference bound was exceeded.")
+    }
+
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
 
@@ -211,7 +216,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
 
@@ -220,12 +225,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
                 );
             });
         }
@@ -315,7 +320,7 @@ mod proxy_signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.bounded_external_ref(),
+                    &context.weak_bounded_external_ref(),
                     true,
                 );
                 let call = context.create_signed_mint_single_nft_call();
@@ -437,7 +442,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -478,7 +483,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -519,7 +524,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -563,7 +568,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -609,7 +614,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -652,7 +657,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -739,7 +744,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
 
@@ -754,12 +759,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
                 );
             });
         }
@@ -839,7 +844,7 @@ mod signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.bounded_external_ref(),
+                    &context.weak_bounded_external_ref(),
                     true,
                 );
                 let proof = context.create_signed_mint_single_nft_proof();
@@ -982,7 +987,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1021,7 +1026,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1060,7 +1065,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1102,7 +1107,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1146,7 +1151,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1187,7 +1192,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());


### PR DESCRIPTION
Convers UsedExternalReferences keys into WeakBoundedVector and adds migration that truncates and updates the keys where needed.

This is done as a stopgap solution, to transform any keys that exceed the bounds. Once all chains are successfully migrated, UsedExternalReferences will be reverted back to using Bounded Vectors

Review with conjunction to #194 
