### PR TITLE
SYS-3338 Finalises NFT manager data migration to bounded data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-finality-tracker"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-transactions"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -150,7 +150,7 @@ impl<T: Config> MintSingleNft<T> {
     fn setup(self) -> Self {
         <Nfts<T>>::remove(&self.nft_id);
         <NftInfos<T>>::remove(&self.nft_id);
-        <UsedExternalReferences<T>>::remove(&self.weak_bounded_external_ref());
+        <UsedExternalReferences<T>>::remove(&self.unique_external_ref);
         return self
     }
 
@@ -164,11 +164,6 @@ impl<T: Config> MintSingleNft<T> {
             t1_authority: self.t1_authority,
         }
         .into()
-    }
-
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
-        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
-            .expect("Unique external reference bound was exceeded.")
     }
 }
 
@@ -486,11 +481,6 @@ impl<T: Config> MintBatchNft<T> {
         }
     }
 
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
-        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
-            .expect("Unique external reference bound was exceeded.")
-    }
-
     fn generate_signed_mint_batch_nft(
         &self,
         batch_id: U256,
@@ -617,8 +607,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -652,8 +642,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -775,8 +765,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: mint_nft.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
@@ -878,8 +868,8 @@ benchmarks! {
             Nft::new(context.nft_id, U256::zero(), context.unique_external_ref.clone(), context.nft_owner.clone()),
             Nfts::<T>::get(&context.nft_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(context.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(context.unique_external_ref));
 
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: context.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::BatchNftMinted {

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -563,7 +563,7 @@ impl MintBatchNftContext {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
         <UsedExternalReferences<TestRuntime>>::remove(
-            &WeakBoundedVec::try_from(self.unique_external_ref.clone())
+            &BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded."),
         );
     }
@@ -650,7 +650,7 @@ mod signed_mint_batch_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        WeakBoundedVec::try_from(context.unique_external_ref)
+                        BoundedVec::try_from(context.unique_external_ref)
                             .expect("Unique external reference bound was exceeded.")
                     )
                 );

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.weak_bounded_external_ref());
+        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -135,11 +135,6 @@ impl Context {
 
     pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
         BoundedVec::try_from(self.unique_external_ref.clone())
-            .expect("Unique external reference bound was exceeded.")
-    }
-
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
-        WeakBoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
 
@@ -216,7 +211,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -225,12 +220,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -320,7 +315,7 @@ mod proxy_signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.weak_bounded_external_ref(),
+                    &context.bounded_external_ref(),
                     true,
                 );
                 let call = context.create_signed_mint_single_nft_call();
@@ -442,7 +437,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -483,7 +478,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -524,7 +519,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -568,7 +563,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -614,7 +609,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -657,7 +652,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -744,7 +739,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -759,12 +754,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -844,7 +839,7 @@ mod signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.weak_bounded_external_ref(),
+                    &context.bounded_external_ref(),
                     true,
                 );
                 let proof = context.create_signed_mint_single_nft_proof();
@@ -987,7 +982,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1026,7 +1021,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1065,7 +1060,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1107,7 +1102,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1151,7 +1146,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1192,7 +1187,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 34,
+    spec_version: 35,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 34,
+    spec_version: 35,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Revert the stopgap solution for the migration and the migration code itself.
This should be included in a separate release from the original migration.

~Do not merge till #193 is merged and included in a release.~ - **Done**

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

