### PR TITLE
SYS-3338 make nft manager storage items bounded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-finality-tracker"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-transactions"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7055,6 +7055,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
+ "log",
  "pallet-avn",
  "parity-scale-codec 3.2.1",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/node/src/chain_spec/stable/mod.rs
+++ b/node/src/chain_spec/stable/mod.rs
@@ -103,6 +103,7 @@ pub(crate) fn testnet_genesis(
         aura: Default::default(),
         aura_ext: Default::default(),
         im_online: ImOnlineConfig { keys: vec![] },
+        nft_manager: Default::default(),
         parachain_system: Default::default(),
         parachain_staking: ParachainStakingConfig {
             candidates: candidates

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -6,7 +6,7 @@ use frame_system as system;
 use hex_literal::hex;
 use pallet_balances;
 use pallet_nft_manager::nft_data::Royalty;
-use sp_core::{sr25519, Pair, H160, H256};
+use sp_core::{sr25519, ConstU32, Pair, H160, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::{Header, UintAuthorityId},
@@ -113,6 +113,7 @@ impl pallet_nft_manager::Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = ConstU32<10>;
 }
 
 impl pallet_avn::Config for TestRuntime {

--- a/pallets/avn/src/vote.rs
+++ b/pallets/avn/src/vote.rs
@@ -12,7 +12,10 @@ use frame_support::{
     ensure,
 };
 use sp_application_crypto::RuntimeAppPublic;
-use sp_avn_common::{event_types::Validator, MaximumValidatorsBound, VotingSessionIdBound};
+use sp_avn_common::{
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    event_types::Validator,
+};
 use sp_core::ecdsa;
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/nft-manager/Cargo.toml
+++ b/pallets/nft-manager/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+log = "0.4"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 hex-literal = { version = "0.3.4", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }

--- a/pallets/nft-manager/Cargo.toml
+++ b/pallets/nft-manager/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4.17", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 hex-literal = { version = "0.3.4", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
@@ -48,6 +48,7 @@ std = [
     'frame-system/std',
     'pallet-avn/std',
     'sp-avn-common/std',
+    'log/std',
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/nft-manager/src/batch_nft.rs
+++ b/pallets/nft-manager/src/batch_nft.rs
@@ -16,12 +16,13 @@
 
 use crate::{
     keccak_256, BatchInfoId, BatchOpenForSale, Config, Decode, DispatchResult, Encode, Error,
-    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftInfo, NftInfoId,
-    NftInfos, NftSaleType, NftUniqueId, Nfts, Pallet, ProcessedEventsChecker, Proof, Royalty, Vec,
-    BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160, U256,
+    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftExternalRefBound,
+    NftInfo, NftInfoId, NftInfos, NftSaleType, NftUniqueId, Nfts, Pallet, ProcessedEventsChecker,
+    Proof, Royalty, Vec, BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160, U256,
 };
 use frame_support::{dispatch::DispatchError, ensure};
 use sp_avn_common::event_types::NftMintData;
+use sp_core::bounded::BoundedVec;
 
 pub const SIGNED_CREATE_BATCH_CONTEXT: &'static [u8] = b"authorization for create batch operation";
 pub const SIGNED_MINT_BATCH_NFT_CONTEXT: &'static [u8] =
@@ -149,12 +150,17 @@ pub fn process_mint_batch_nft_event<T: Config>(
     let owner = T::AccountId::decode(&mut data.t2_owner_public_key.as_bytes())
         .expect("32 bytes will always decode into an AccountId");
 
-    Ok(mint_batch_nft::<T>(data.batch_id, owner, data.sale_index, &data.unique_external_ref)?)
+    Ok(mint_batch_nft::<T>(
+        data.batch_id,
+        owner,
+        data.sale_index,
+        data.unique_external_ref.clone(),
+    )?)
 }
 
 pub fn validate_mint_batch_nft_request<T: Config>(
     batch_id: NftBatchId,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
 ) -> Result<NftInfo<T::AccountId>, DispatchError> {
     ensure!(batch_id.is_zero() == false, Error::<T>::BatchIdIsMandatory);
     ensure!(<BatchInfoId<T>>::contains_key(&batch_id), Error::<T>::BatchDoesNotExist);
@@ -175,13 +181,13 @@ pub fn mint_batch_nft<T: Config>(
     batch_id: NftBatchId,
     owner: T::AccountId,
     sale_index: u64,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
 ) -> DispatchResult {
-    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, unique_external_ref)?;
+    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, &unique_external_ref)?;
     let nft_id = generate_batch_nft_id::<T>(&batch_id, &sale_index);
     ensure!(<Nfts<T>>::contains_key(&nft_id) == false, Error::<T>::NftAlreadyExists);
 
-    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref.to_vec(), owner.clone());
+    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref, owner.clone());
     Pallet::<T>::add_nft_and_update_owner(&owner, &nft);
 
     let mut nfts_for_batch = <NftBatches<T>>::get(batch_id);

--- a/pallets/nft-manager/src/batch_nft.rs
+++ b/pallets/nft-manager/src/batch_nft.rs
@@ -189,7 +189,7 @@ pub fn mint_batch_nft<T: Config>(
     ensure!(<Nfts<T>>::contains_key(&nft_id) == false, Error::<T>::NftAlreadyExists);
 
     let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref, owner.clone());
-    Pallet::<T>::add_nft_and_update_owner(&owner, &nft);
+    Pallet::<T>::add_nft(&nft);
 
     let mut nfts_for_batch = <NftBatches<T>>::get(batch_id);
     nfts_for_batch.try_push(nft_id).map_err(|_| Error::<T>::BatchOutOfBounds)?;

--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -150,7 +150,7 @@ impl<T: Config> MintSingleNft<T> {
     fn setup(self) -> Self {
         <Nfts<T>>::remove(&self.nft_id);
         <NftInfos<T>>::remove(&self.nft_id);
-        <UsedExternalReferences<T>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<T>>::remove(&self.weak_bounded_external_ref());
         return self
     }
 
@@ -164,6 +164,11 @@ impl<T: Config> MintSingleNft<T> {
             t1_authority: self.t1_authority,
         }
         .into()
+    }
+
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
+            .expect("Unique external reference bound was exceeded.")
     }
 }
 
@@ -481,6 +486,11 @@ impl<T: Config> MintBatchNft<T> {
         }
     }
 
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
+            .expect("Unique external reference bound was exceeded.")
+    }
+
     fn generate_signed_mint_batch_nft(
         &self,
         batch_id: U256,
@@ -607,8 +617,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -642,8 +652,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -765,8 +775,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: mint_nft.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
@@ -868,8 +878,8 @@ benchmarks! {
             Nft::new(context.nft_id, U256::zero(), context.unique_external_ref.clone(), context.nft_owner.clone()),
             Nfts::<T>::get(&context.nft_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.unique_external_ref));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(context.unique_external_ref));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(context.weak_bounded_external_ref()));
 
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: context.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::BatchNftMinted {

--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -71,6 +71,10 @@ fn bounded_unique_external_ref() -> BoundedVec<u8, NftExternalRefBound> {
         .expect("Unique external reference bound was exceeded.")
 }
 
+pub fn bounded_royalties(royalties: Vec<Royalty>) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+    BoundedVec::try_from(royalties.clone()).expect("Royalty bound was exceeded.")
+}
+
 fn get_relayer<T: Config>() -> T::AccountId {
     let relayer_account: H256 =
         H256(hex!("0000000000000000000000000000000000000000000000000000000000000001"));
@@ -348,12 +352,12 @@ struct CreateBatch<T: Config> {
 }
 
 impl<T: Config> CreateBatch<T> {
-    fn new(number_of_royalties: u32) -> Self {
+    fn new(batch_size: u32) -> Self {
         let relayer_account_id = get_relayer::<T>();
         let (creator_key_pair, creator_account_id) = get_user_account::<T>();
 
-        let total_supply = 100;
-        let royalties = Self::setup_royalties(number_of_royalties);
+        let total_supply = batch_size as u64;
+        let royalties = Self::setup_royalties(NftRoyaltiesBound::get());
         let t1_authority = H160(hex!("0000000000000000000000000000000000000001"));
         let nonce = 0u64;
 
@@ -406,7 +410,7 @@ impl<T: Config> CreateBatch<T> {
         create_batch::<T>(
             U256::zero(),
             batch_id,
-            self.royalties.clone(),
+            self.bounded_royalties(),
             self.total_supply,
             self.t1_authority,
             self.creator_account_id.clone(),
@@ -415,6 +419,10 @@ impl<T: Config> CreateBatch<T> {
         <BatchNonces<T>>::mutate(&self.creator_account_id, |n| *n += 1);
 
         return batch_id
+    }
+
+    pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+        bounded_royalties(self.royalties.clone())
     }
 }
 
@@ -435,7 +443,7 @@ impl<T: Config> MintBatchNft<T> {
         let (nft_owner_key_pair, nft_owner_account_id) = get_user_account::<T>();
 
         // create batch and list
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
         <BatchOpenForSale<T>>::insert(batch_id, NftSaleType::Fiat);
 
@@ -506,7 +514,7 @@ impl<T: Config> ListBatch<T> {
 
         let market = NftSaleType::Fiat;
 
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
         let nonce = <BatchNonces<T>>::get(&creator_account_id);
 
@@ -551,7 +559,7 @@ impl<T: Config> EndBatchSale<T> {
 
         let market = NftSaleType::Fiat;
 
-        let batch: CreateBatch<T> = CreateBatch::new(1);
+        let batch: CreateBatch<T> = CreateBatch::new(T::BatchBound::get());
         let batch_id = batch.create_batch_for_setup();
 
         <BatchOpenForSale<T>>::insert(batch_id, market);
@@ -596,7 +604,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -631,7 +639,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -754,7 +762,7 @@ benchmarks! {
         );
         assert_eq!(true, NftInfos::<T>::contains_key(&mint_nft.info_id));
         assert_eq!(
-            NftInfo::new(mint_nft.info_id, mint_nft.royalties, mint_nft.t1_authority),
+            NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
         assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.unique_external_ref));
@@ -822,7 +830,7 @@ benchmarks! {
     }
 
     proxy_signed_create_batch {
-        let r in 1 .. MAX_NUMBER_OF_ROYALTIES;
+        let r in 1 .. T::BatchBound::get();
         let batch: CreateBatch<T> = CreateBatch::new(r);
         let call: <T as Config>::RuntimeCall = batch.generate_signed_create_batch();
         let boxed_call: Box<<T as Config>::RuntimeCall> = Box::new(call);

--- a/pallets/nft-manager/src/lib.rs
+++ b/pallets/nft-manager/src/lib.rs
@@ -1322,9 +1322,9 @@ pub mod migrations {
         log::info!("ℹ️  Nft manager pallet data migration invoked");
 
         let mut keys_need_update = Vec::<Vec<u8>>::new();
+        let bound: usize = <NftExternalRefBound as sp_core::Get<u32>>::get() as usize;
 
         Nfts::<T>::translate::<OldNft<T::AccountId>, _>(|_, p| {
-            let bound: usize = <NftExternalRefBound as sp_core::Get<u32>>::get() as usize;
             if p.unique_external_ref.len() > bound {
                 keys_need_update.push(p.unique_external_ref.clone());
             }

--- a/pallets/nft-manager/src/lib.rs
+++ b/pallets/nft-manager/src/lib.rs
@@ -123,6 +123,25 @@ pub mod pallet {
         type BatchBound: Get<u32>;
     }
 
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub _phantom: sp_std::marker::PhantomData<T>,
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self { _phantom: Default::default() }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            crate::STORAGE_VERSION.put::<Pallet<T>>();
+        }
+    }
+
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
     #[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -41,7 +41,7 @@ impl RoyaltyRate {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct Nft<AccountId: Member> {
     /// Unique identifier of a nft
     pub nft_id: NftId,
@@ -77,14 +77,14 @@ impl<AccountId: Member> Nft<AccountId> {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct NftInfo<AccountId: Member> {
     /// Unique identifier of this information
     pub info_id: NftInfoId,
     /// Batch Id defined by client
     pub batch_id: Option<NftBatchId>,
     /// Royalties payment rate for the nft.
-    pub royalties: Vec<Royalty>,
+    pub royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
     /// Total supply of NFTs in this collection:
     ///  - 1: it is for a singleton
     ///  - >1: it is for a batch
@@ -97,7 +97,11 @@ pub struct NftInfo<AccountId: Member> {
 }
 
 impl<AccountId: Member> NftInfo<AccountId> {
-    pub fn new(info_id: NftInfoId, royalties: Vec<Royalty>, t1_authority: H160) -> Self {
+    pub fn new(
+        info_id: NftInfoId,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
+        t1_authority: H160,
+    ) -> Self {
         return NftInfo::<AccountId> {
             info_id,
             batch_id: None,
@@ -111,7 +115,7 @@ impl<AccountId: Member> NftInfo<AccountId> {
     pub fn new_batch(
         info_id: NftInfoId,
         batch_id: NftBatchId,
-        royalties: Vec<Royalty>,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
         t1_authority: H160,
         total_supply: u64,
         creator: AccountId,

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -15,8 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
+use sp_core::bounded::BoundedVec;
 use sp_runtime::traits::Member;
 
+pub(crate) use sp_avn_common::bounds::NftExternalRefBound;
 pub const ROYALTY_RATE_DENOMINATOR: u32 = 1_000_000;
 
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq, MaxEncodedLen, TypeInfo)]
@@ -46,7 +48,7 @@ pub struct Nft<AccountId: Member> {
     /// Id of an info struct instance
     pub info_id: NftInfoId,
     /// Unique reference to the NFT asset stored off-chain
-    pub unique_external_ref: Vec<u8>,
+    pub unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
     /// Transfer nonce of this NFT
     pub nonce: u64,
     /// Owner account address of this NFT
@@ -61,7 +63,7 @@ impl<AccountId: Member> Nft<AccountId> {
     pub fn new(
         nft_id: NftId,
         info_id: NftInfoId,
-        unique_external_ref: Vec<u8>,
+        unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
         owner: AccountId,
     ) -> Self {
         return Nft::<AccountId> {

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -515,7 +515,10 @@ impl MintBatchNftContext {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<TestRuntime>>::remove(
+            &BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded."),
+        );
     }
 
     fn create_signed_mint_batch_nft_call(
@@ -603,7 +606,8 @@ mod signed_mint_batch_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        BoundedVec::try_from(context.unique_external_ref)
+                            .expect("Unique external reference bound was exceeded.")
                     )
                 );
 
@@ -757,6 +761,28 @@ mod signed_mint_batch_nft {
                 assert_noop!(
                     NftManager::proxy(Origin::signed(context.relayer), inner_call),
                     Error::<TestRuntime>::ExternalRefIsMandatory
+                );
+            });
+        }
+
+        #[test]
+        fn external_ref_is_out_of_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context = MintBatchNftContext::default();
+                context.setup();
+
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
+
+                let index = 0u64;
+                let batch_id = create_batch_and_list();
+
+                let inner_call = context.create_signed_mint_batch_nft_call(batch_id, index);
+
+                assert_noop!(
+                    NftManager::proxy(Origin::signed(context.relayer), inner_call),
+                    Error::<TestRuntime>::ExternalRefOutOfBounds
                 );
             });
         }

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -637,9 +637,6 @@ mod signed_mint_batch_nft {
                 // Nft has been minted
                 assert_eq!(true, <Nfts<TestRuntime>>::contains_key(&context.nft_id));
 
-                // Ownership data is updated
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-
                 // Batch_id map has been created
                 assert!(<NftBatches<TestRuntime>>::contains_key(&batch_id));
 
@@ -692,22 +689,6 @@ mod signed_mint_batch_nft {
 
                 // 2 Nfts minted and assigned to the same batch
                 assert_eq!(<NftBatches<TestRuntime>>::get(batch_id).len(), 2);
-
-                // Ownership data is updated
-                assert_eq!(
-                    true,
-                    nft_is_owned(
-                        &context.nft_owner_account,
-                        &<NftBatches<TestRuntime>>::get(batch_id)[0]
-                    )
-                );
-                assert_eq!(
-                    true,
-                    nft_is_owned(
-                        &context.nft_owner_account,
-                        &<NftBatches<TestRuntime>>::get(batch_id)[1]
-                    )
-                );
             });
         }
     }

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -563,7 +563,7 @@ impl MintBatchNftContext {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
         <UsedExternalReferences<TestRuntime>>::remove(
-            &BoundedVec::try_from(self.unique_external_ref.clone())
+            &WeakBoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded."),
         );
     }
@@ -650,7 +650,7 @@ mod signed_mint_batch_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        BoundedVec::try_from(context.unique_external_ref)
+                        WeakBoundedVec::try_from(context.unique_external_ref)
                             .expect("Unique external reference bound was exceeded.")
                     )
                 );

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -87,13 +87,18 @@ mod cancel_single_nft_listing {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
         }
 
         pub fn cancel_nft_listing_data(&self) -> NftCancelListingData {
             return NftCancelListingData { nft_id: self.nft_id(), op_id: self.op_id }
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -84,7 +84,7 @@ mod cancel_single_nft_listing {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -99,6 +99,10 @@ mod cancel_single_nft_listing {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -158,11 +158,3 @@ impl TestAccount {
 pub fn sign(signer: &sr25519::Pair, message_to_sign: &[u8]) -> Signature {
     return Signature::from(signer.sign(message_to_sign))
 }
-
-pub fn nft_is_owned(owner: &AccountId, nft_id: &NftId) -> bool {
-    if <OwnedNfts<TestRuntime>>::contains_key(&owner) {
-        return NftManager::get_owned_nfts(owner).iter().any(|nft| nft == nft_id)
-    }
-
-    return false
-}

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -19,7 +19,7 @@
 use frame_support::parameter_types;
 use frame_system as system;
 use sp_avn_common::event_types::EthEventId;
-use sp_core::{sr25519, Pair, H256};
+use sp_core::{sr25519, ConstU32, Pair, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::Header,
@@ -39,6 +39,7 @@ pub type Hashing = <TestRuntime as system::Config>::Hashing;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
+pub type MockNftBatchBound = ConstU32<8>;
 
 frame_support::construct_runtime!(
     pub enum TestRuntime where
@@ -59,6 +60,7 @@ impl Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = MockNftBatchBound;
 }
 
 parameter_types! {

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -81,7 +81,7 @@ mod open_for_sale {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -92,6 +92,10 @@ mod open_for_sale {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -84,9 +84,14 @@ mod open_for_sale {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
@@ -66,7 +66,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
@@ -68,7 +68,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Test string should not exceed bound"),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -132,6 +132,11 @@ impl Context {
                 })
         })
     }
+
+    pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+        BoundedVec::try_from(self.unique_external_ref.clone())
+            .expect("Unique external reference bound was exceeded.")
+    }
 }
 
 mod proxy_signed_mint_single_nft {
@@ -160,7 +165,7 @@ mod proxy_signed_mint_single_nft {
                     Nft::new(
                         context.nft_id,
                         context.info_id,
-                        context.unique_external_ref,
+                        context.bounded_external_ref(),
                         context.nft_owner_account
                     ),
                     <Nfts<TestRuntime>>::get(&context.nft_id).unwrap()
@@ -200,7 +205,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -209,12 +214,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.unique_external_ref)
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -305,7 +310,10 @@ mod proxy_signed_mint_single_nft {
             ext.execute_with(|| {
                 let context = Context::default();
                 context.setup();
-                <UsedExternalReferences<TestRuntime>>::insert(&context.unique_external_ref, true);
+                <UsedExternalReferences<TestRuntime>>::insert(
+                    &context.bounded_external_ref(),
+                    true,
+                );
                 let call = context.create_signed_mint_single_nft_call();
 
                 assert_noop!(
@@ -425,7 +433,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -466,7 +474,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -507,7 +515,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -551,7 +559,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -572,7 +580,7 @@ mod proxy_signed_mint_single_nft {
                 let data_to_sign = (
                     SIGNED_MINT_SINGLE_NFT_CONTEXT,
                     &context.relayer,
-                    &context.unique_external_ref,
+                    &context.bounded_external_ref(),
                     other_royalties,
                     context.t1_authority,
                 );
@@ -597,7 +605,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -640,7 +648,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -669,7 +677,7 @@ mod signed_mint_single_nft {
                     Origin::signed(context.nft_owner_account),
                     proof,
                     context.unique_external_ref.clone(),
-                    context.royalties,
+                    context.royalties.clone(),
                     context.t1_authority
                 ));
 
@@ -678,7 +686,7 @@ mod signed_mint_single_nft {
                     Nft::new(
                         context.nft_id,
                         context.info_id,
-                        context.unique_external_ref,
+                        context.bounded_external_ref(),
                         context.nft_owner_account
                     ),
                     <Nfts<TestRuntime>>::get(&context.nft_id).unwrap()
@@ -723,7 +731,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -738,12 +746,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.unique_external_ref)
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -759,7 +767,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -849,7 +857,10 @@ mod signed_mint_single_nft {
             ext.execute_with(|| {
                 let context = Context::default();
                 context.setup();
-                <UsedExternalReferences<TestRuntime>>::insert(&context.unique_external_ref, true);
+                <UsedExternalReferences<TestRuntime>>::insert(
+                    &context.bounded_external_ref(),
+                    true,
+                );
                 let proof = context.create_signed_mint_single_nft_proof();
 
                 assert_noop!(
@@ -990,7 +1001,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1029,7 +1040,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1068,7 +1079,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1110,7 +1121,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1154,7 +1165,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1195,7 +1206,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
+        <UsedExternalReferences<TestRuntime>>::remove(&self.weak_bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -135,6 +135,11 @@ impl Context {
 
     pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
         BoundedVec::try_from(self.unique_external_ref.clone())
+            .expect("Unique external reference bound was exceeded.")
+    }
+
+    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+        WeakBoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
 
@@ -211,7 +216,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
 
@@ -220,12 +225,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
                 );
             });
         }
@@ -315,7 +320,7 @@ mod proxy_signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.bounded_external_ref(),
+                    &context.weak_bounded_external_ref(),
                     true,
                 );
                 let call = context.create_signed_mint_single_nft_call();
@@ -437,7 +442,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -478,7 +483,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -519,7 +524,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -563,7 +568,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -609,7 +614,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -652,7 +657,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -739,7 +744,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
 
@@ -754,12 +759,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
                 );
             });
         }
@@ -839,7 +844,7 @@ mod signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.bounded_external_ref(),
+                    &context.weak_bounded_external_ref(),
                     true,
                 );
                 let proof = context.create_signed_mint_single_nft_proof();
@@ -982,7 +987,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1021,7 +1026,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1060,7 +1065,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1102,7 +1107,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1146,7 +1151,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1187,7 +1192,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
+                        &context.weak_bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -137,6 +137,10 @@ impl Context {
         BoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
+
+    pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+        BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
+    }
 }
 
 mod proxy_signed_mint_single_nft {
@@ -188,7 +192,11 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&context.info_id));
 
                 assert_eq!(
-                    NftInfo::new(context.info_id, context.royalties, context.t1_authority),
+                    NftInfo::new(
+                        context.info_id,
+                        context.bounded_royalties(),
+                        context.t1_authority
+                    ),
                     <NftInfos<TestRuntime>>::get(&context.info_id).unwrap()
                 );
             });
@@ -707,14 +715,18 @@ mod signed_mint_single_nft {
                 assert_ok!(NftManager::signed_mint_single_nft(
                     Origin::signed(context.nft_owner_account),
                     proof,
-                    context.unique_external_ref,
+                    context.unique_external_ref.clone(),
                     context.royalties.clone(),
                     context.t1_authority
                 ));
 
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&context.info_id));
                 assert_eq!(
-                    NftInfo::new(context.info_id, context.royalties, context.t1_authority),
+                    NftInfo::new(
+                        context.info_id,
+                        context.bounded_royalties(),
+                        context.t1_authority
+                    ),
                     <NftInfos<TestRuntime>>::get(&context.info_id).unwrap()
                 );
             });

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -163,8 +163,6 @@ mod proxy_signed_mint_single_nft {
 
                 assert_eq!(true, <Nfts<TestRuntime>>::contains_key(&context.nft_id));
 
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-
                 assert_eq!(
                     Nft::new(
                         context.nft_id,
@@ -259,8 +257,6 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(false, context.call_dispatched_event_emitted(&call));
 
                 assert_ok!(NftManager::proxy(Origin::signed(context.relayer), call.clone()));
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
             });
         }
 
@@ -765,33 +761,6 @@ mod signed_mint_single_nft {
                     true,
                     <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
-            });
-        }
-
-        #[test]
-        fn owned_nft_list_is_updated_test() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context = Context::default();
-                context.setup();
-                let proof = context.create_signed_mint_single_nft_proof();
-
-                assert_eq!(
-                    false,
-                    <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.bounded_external_ref()
-                    )
-                );
-
-                assert_ok!(NftManager::signed_mint_single_nft(
-                    Origin::signed(context.nft_owner_account),
-                    proof,
-                    context.unique_external_ref.clone(),
-                    context.royalties.clone(),
-                    context.t1_authority
-                ));
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
             });
         }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
@@ -74,7 +74,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
@@ -79,7 +79,6 @@ impl Context {
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);
-        <NftManager as Store>::OwnedNfts::insert(self.nft_owner_account, vec![self.nft_id]);
         <NftManager as Store>::NftOpenForSale::insert(&self.nft_id, NftSaleType::Fiat);
     }
 
@@ -153,34 +152,6 @@ mod proxy_signed_transfer_fiat_nft {
                 assert_ok!(NftManager::proxy(Origin::signed(context.relayer), call));
 
                 assert_eq!(false, <NftOpenForSale<TestRuntime>>::contains_key(&context.nft_id));
-            });
-        }
-
-        #[test]
-        fn nft_ownership_is_updated() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context = Context::default();
-                context.setup();
-                let call = context.create_signed_transfer_fiat_nft_call();
-
-                assert_eq!(
-                    context.nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(false, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
-
-                assert_ok!(NftManager::proxy(Origin::signed(context.relayer), call));
-
-                assert_eq!(
-                    context.new_nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(false, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(true, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
             });
         }
 
@@ -504,39 +475,6 @@ mod signed_transfer_fiat_nft {
                 ));
 
                 assert_eq!(false, <NftOpenForSale<TestRuntime>>::contains_key(&context.nft_id));
-            });
-        }
-
-        #[test]
-        fn nft_ownership_is_updated() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context = Context::default();
-                context.setup();
-                let proof = context.create_signed_transfer_fiat_nft_proof();
-
-                assert_eq!(
-                    context.nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(false, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
-
-                assert_ok!(NftManager::signed_transfer_fiat_nft(
-                    Origin::signed(context.nft_owner_account),
-                    proof,
-                    context.nft_id,
-                    context.t2_transfer_to_public_key
-                ));
-
-                assert_eq!(
-                    context.new_nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(false, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(true, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
             });
         }
 

--- a/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
@@ -100,7 +100,6 @@ mod mint_single_nft {
 
                 assert_eq!(true, <Nfts<TestRuntime>>::contains_key(&nft_id));
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
-                assert_eq!(true, nft_is_owned(&context.owner, &context.generate_nft_id()));
                 assert_eq!(true, context.event_emitted_with_single_nft_minted());
             });
         }

--- a/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
@@ -170,6 +170,28 @@ mod mint_single_nft {
         }
 
         #[test]
+        fn external_ref_is_out_of_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context: Context = Default::default();
+                let expected_info_id: NftInfoId = NftManager::next_info_id();
+
+                assert_eq!(false, <Nfts<TestRuntime>>::contains_key(&context.generate_nft_id()));
+                assert_eq!(false, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
+
+                assert_noop!(
+                    context.call_mint_single_nft(),
+                    Error::<TestRuntime>::ExternalRefOutOfBounds
+                );
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+            });
+        }
+
+        #[test]
         fn external_ref_is_taken() {
             let mut ext = ExtBuilder::build_default().as_externality();
             ext.execute_with(|| {

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -88,7 +88,7 @@ mod transfer_eth_nft {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
                 self.bounded_external_ref(),
@@ -121,6 +121,10 @@ mod transfer_eth_nft {
         pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
             BoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -157,28 +157,6 @@ mod transfer_eth_nft {
         }
 
         #[test]
-        fn ownership_is_updated() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context: Context = Default::default();
-                context.setup_valid_transfer();
-
-                let new_nft_owner = context.new_owner_to_account_id();
-                let nft_id = context.nft_id();
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner, &nft_id));
-                assert_eq!(false, nft_is_owned(&new_nft_owner, &nft_id));
-
-                assert_ok!(context.perform_transfer());
-
-                assert_eq!(new_nft_owner, NftManager::nfts(context.nft_id()).unwrap().owner);
-
-                assert_eq!(false, nft_is_owned(&context.nft_owner, &nft_id));
-                assert_eq!(true, nft_is_owned(&new_nft_owner, &nft_id));
-            });
-        }
-
-        #[test]
         fn nft_is_not_listed_for_sale_anymore() {
             let mut ext = ExtBuilder::build_default().as_externality();
             ext.execute_with(|| {

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -91,7 +91,7 @@ mod transfer_eth_nft {
                 self.royalties.clone(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
         }
@@ -116,6 +116,11 @@ mod transfer_eth_nft {
 
         pub fn perform_transfer(&self) -> DispatchResult {
             return NftManager::transfer_eth_nft(&self.event_id, &self.transfer_to_nft_data())
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
         }
     }
 

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -10,7 +10,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.101", optional = true }
 rand = { version = "0.7.2", default-features = false }
 # Substrate
@@ -53,6 +53,8 @@ std = [
 	"pallet-authorship/std",
 	"pallet-avn/std",
 	"pallet-session/std",
+	"log/std",
+
 ]
 runtime-benchmarks = [ "frame-benchmarking" ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -7,10 +7,11 @@ use alloc::string::{String, ToString};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::{
+    bounds::VotingSessionIdBound,
     calculate_two_third_quorum,
     event_types::Validator,
     offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
-    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter, VotingSessionIdBound,
+    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter,
 };
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -1721,7 +1721,7 @@ mod if_process_summary_is_called_a_second_time {
 mod constrains {
     use crate::{RootId, RootRange};
     use node_primitives::BlockNumber;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::Get;
 
     #[test]

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -44,8 +44,11 @@ use pallet_ethereum_transactions::{
 };
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
-    calculate_two_third_quorum, eth_key_actions::decompress_eth_public_key, event_types::Validator,
-    safe_add_block_numbers, IngressCounter, MaximumValidatorsBound, VotingSessionIdBound,
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    calculate_two_third_quorum,
+    eth_key_actions::decompress_eth_public_key,
+    event_types::Validator,
+    safe_add_block_numbers, IngressCounter,
 };
 use sp_core::{bounded::BoundedVec, ecdsa, H512};
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -618,7 +618,7 @@ mod add_validator {
 mod constrains {
 
     use crate::ActionId;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::{sr25519::Public, Get};
 
     #[test]

--- a/primitives/avn-common/Cargo.toml
+++ b/primitives/avn-common/Cargo.toml
@@ -26,7 +26,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-log = { version = "0.4.17", default-features = false, features = ["std"]  }
+log = { version = "0.4.17", default-features = false }
 
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
 sha3 = { version = "0.8", default-features = false }

--- a/primitives/avn-common/Cargo.toml
+++ b/primitives/avn-common/Cargo.toml
@@ -26,7 +26,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-log = { version = "0.4.8", optional = true, features = ["std"] }
+log = { version = "0.4.17", default-features = false, features = ["std"]  }
 
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
 sha3 = { version = "0.8", default-features = false }
@@ -36,7 +36,6 @@ byte-slice-cast = "1.2.1"
 sha3 = {version = "0.8.2", default-features = false }
 
 [features]
-default = [ "std" ]
 std = [
 	"serde",
 	"codec/std",
@@ -44,7 +43,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"log",
+	"log/std",
 	"libsecp256k1/std",
 	"sha3/std"
 ]

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use codec::{Codec, Decode, Encode};
-use sp_core::{crypto::KeyTypeId, ecdsa, ConstU32, H160};
+use sp_core::{crypto::KeyTypeId, ecdsa, H160};
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::keccak_256, EcdsaVerifyError};
 use sp_runtime::{
     scale_info::TypeInfo,
@@ -38,10 +38,17 @@ pub const ETHEREUM_PREFIX: &'static [u8] = b"\x19Ethereum Signed Message:\n32";
 pub const EXTERNAL_SERVICE_PORT_NUMBER_KEY: &'static [u8; 15] = b"avn_port_number";
 /// Default port number the external service runs on.
 pub const DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER: &str = "2020";
-/// Bound used for Vectors containing validators
-pub type MaximumValidatorsBound = ConstU32<256>;
-/// Bound used for voting session IDs
-pub type VotingSessionIdBound = ConstU32<64>;
+
+pub mod bounds {
+    use sp_core::ConstU32;
+
+    /// Bound used for Vectors containing validators
+    pub type MaximumValidatorsBound = ConstU32<256>;
+    /// Bound used for voting session IDs
+    pub type VotingSessionIdBound = ConstU32<64>;
+    /// Bound used for NFT external references
+    pub type NftExternalRefBound = ConstU32<1024>;
+}
 
 #[derive(Debug)]
 pub enum ECDSAVerificationError {

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 33,
+    spec_version: 34,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -639,6 +639,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
+    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -658,6 +658,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
+    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 33,
+    spec_version: 34,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Converts the nft manager storage items bounded.
This includes:
- batch size
- external references
- royalties

Added migration truncating and updating data that exceeded the boundaries
Updated tests and benchmarks
Updated log library std dependencies

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
