### PR TITLE
SYS-3556 Convert ethereum-transactions pallet to use BoundedVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-finality-tracker"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-transactions"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "3.2.3"
+version = "3.2.4"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/ethereum-transactions/src/benchmarking.rs
+++ b/pallets/ethereum-transactions/src/benchmarking.rs
@@ -76,10 +76,12 @@ fn add_eth_tx_candidate_to_candidate_tx_id<T: Config>(
 }
 
 fn add_tx_ids_to_account<T: Config>(account: &T::AccountId, candidate_tx_ids: Vec<TransactionId>) {
-    let dispatch_data: Vec<DispatchedData<T::BlockNumber>> = candidate_tx_ids
+    let dispatch_data_vec = candidate_tx_ids
         .iter()
         .map(|id| DispatchedData::new(*id, 0u32.into()))
         .collect();
+    let dispatch_data: BoundedVec<DispatchedData<T::BlockNumber>, TransactionIdLimit> =
+        BoundedVec::truncate_from(dispatch_data_vec);
     DispatchedAvnTxIds::<T>::insert(account, dispatch_data);
 }
 

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -1,6 +1,6 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::EthTransaction;
-use sp_core::{ecdsa, H160, H256, H512, U256, ConstU32};
+use sp_core::{ecdsa, ConstU32, H160, H256, H512, U256};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -1,6 +1,6 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::EthTransaction;
-use sp_core::{ecdsa, H160, H256, H512, U256};
+use sp_core::{ecdsa, H160, H256, H512, U256, ConstU32};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -185,7 +185,9 @@ impl ActivateCollatorData {
 pub type TransactionId = u64;
 pub type EthereumTransactionHash = H256;
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
+pub type TransactionIdLimit = ConstU32<{ u32::MAX }>;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
 pub struct EthTransactionCandidate {
     pub tx_id: TransactionId,
     pub from: Option<[u8; 32]>, // AvN Public Key of a validator
@@ -424,6 +426,10 @@ pub struct EthSignatures {
 }
 
 impl EthSignatures {
+    fn max_encoded_len() -> usize {
+        u32::MAX as usize
+    }
+
     pub fn count(&self) -> u32 {
         return self.signatures_list.len() as u32
     }

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -433,10 +433,6 @@ impl EthSignatures {
         return self.signatures_list.len() as u32
     }
 
-    pub fn append(&mut self, mut other: Vec<ecdsa::Signature>) {
-        if let Err(_) = self.signatures_list.try_append(&mut other) {}
-    }
-
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut data = Vec::<u8>::new();
         for sig in self.signatures_list.iter() {
@@ -454,6 +450,13 @@ impl EthSignatures {
             return Err(OtherError::DuplicateSignature)
         }
         if let Err(_) = self.signatures_list.try_push(signature) {
+            return Err(OtherError::ExceededSignatureLimit)
+        }
+        Ok(())
+    }
+
+    pub fn append(&mut self, mut confirmations: Vec<ecdsa::Signature>) -> Result<(), OtherError> {
+        if let Err(_) = self.signatures_list.try_append(&mut confirmations) {
             return Err(OtherError::ExceededSignatureLimit)
         }
         Ok(())

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -1,6 +1,6 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::{bounds::MaximumValidatorsBound, EthTransaction};
-use sp_core::{ecdsa, ConstU32, ConstU64, H160, H256, H512, U256};
+use sp_core::{ecdsa, ConstU32, H160, H256, H512, U256};
 use sp_runtime::BoundedVec;
 
 #[cfg(not(feature = "std"))]
@@ -186,7 +186,7 @@ impl ActivateCollatorData {
 pub type TransactionId = u64;
 pub type EthereumTransactionHash = H256;
 
-pub type TransactionIdLimit = ConstU32<{ u32::MAX }>;
+pub type TransactionIdLimit = ConstU32<1000000>;
 pub type SignaturesLimit = MaximumValidatorsBound;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode, MaxEncodedLen};
-use sp_avn_common::EthTransaction;
+use sp_avn_common::{bounds::MaximumValidatorsBound, EthTransaction};
 use sp_core::{ecdsa, ConstU32, ConstU64, H160, H256, H512, U256};
 use sp_runtime::BoundedVec;
 
@@ -187,7 +187,7 @@ pub type TransactionId = u64;
 pub type EthereumTransactionHash = H256;
 
 pub type TransactionIdLimit = ConstU32<{ u32::MAX }>;
-pub type SignaturesLimit = ConstU32<{ u32::MAX }>;
+pub type SignaturesLimit = MaximumValidatorsBound;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
 pub struct EthTransactionCandidate {

--- a/pallets/ethereum-transactions/src/ethereum_transaction.rs
+++ b/pallets/ethereum-transactions/src/ethereum_transaction.rs
@@ -1,6 +1,7 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::EthTransaction;
-use sp_core::{ecdsa, ConstU32, H160, H256, H512, U256};
+use sp_core::{ecdsa, ConstU32, ConstU64, H160, H256, H512, U256};
+use sp_runtime::BoundedVec;
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -186,6 +187,7 @@ pub type TransactionId = u64;
 pub type EthereumTransactionHash = H256;
 
 pub type TransactionIdLimit = ConstU32<{ u32::MAX }>;
+pub type SignaturesLimit = ConstU32<{ u32::MAX }>;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
 pub struct EthTransactionCandidate {
@@ -368,6 +370,7 @@ impl EthAbiHelper {
 pub enum OtherError {
     InvalidEcdsaData,
     DuplicateSignature,
+    ExceededSignatureLimit,
 }
 
 // TODO [TYPE: refactoring][PRI: medium][JIRA: 92]: replace by some Substrate inbuilt ECDSA type
@@ -418,24 +421,20 @@ impl EcdsaSignature {
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
 pub struct EthSignatures {
     // TODO [TYPE: refactoring][PRI: medium]: make this private and fix tests.rs to deal with it
     // Alternatively: consider removing this struct entirely
-    pub signatures_list: Vec<ecdsa::Signature>,
+    pub signatures_list: BoundedVec<ecdsa::Signature, SignaturesLimit>,
 }
 
 impl EthSignatures {
-    fn max_encoded_len() -> usize {
-        u32::MAX as usize
-    }
-
     pub fn count(&self) -> u32 {
         return self.signatures_list.len() as u32
     }
 
     pub fn append(&mut self, mut other: Vec<ecdsa::Signature>) {
-        self.signatures_list.append(&mut other);
+        if let Err(_) = self.signatures_list.try_append(&mut other) {}
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -454,12 +453,16 @@ impl EthSignatures {
         if self.signatures_list.contains(&signature) {
             return Err(OtherError::DuplicateSignature)
         }
-        self.signatures_list.push(signature);
+        if let Err(_) = self.signatures_list.try_push(signature) {
+            return Err(OtherError::ExceededSignatureLimit)
+        }
         Ok(())
     }
 
     pub fn new() -> Self {
-        return EthSignatures { signatures_list: Vec::<ecdsa::Signature>::new() }
+        return EthSignatures {
+            signatures_list: BoundedVec::<ecdsa::Signature, SignaturesLimit>::default(),
+        }
     }
 }
 

--- a/pallets/ethereum-transactions/src/lib.rs
+++ b/pallets/ethereum-transactions/src/lib.rs
@@ -477,7 +477,7 @@ impl<T: Config> Pallet<T> {
             }
             Self::deposit_event(Event::<T>::TransactionReadyToSend {
                 transaction_id: candidate_tx.tx_id,
-                sender: submitter.clone(),
+                sender: submitter,
             });
         }
         Ok(())

--- a/pallets/ethereum-transactions/src/lib.rs
+++ b/pallets/ethereum-transactions/src/lib.rs
@@ -21,8 +21,7 @@ use sp_runtime::{
         InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
         ValidTransaction,
     },
-    BoundedVec,
-    DispatchError,
+    BoundedVec, DispatchError,
 };
 use sp_std::prelude::*;
 
@@ -38,7 +37,8 @@ pub use pallet::*;
 
 pub mod ethereum_transaction;
 use crate::ethereum_transaction::{
-    EthTransactionCandidate, EthTransactionType, EthereumTransactionHash, TransactionId, TransactionIdLimit
+    EthTransactionCandidate, EthTransactionType, EthereumTransactionHash, TransactionId,
+    TransactionIdLimit,
 };
 
 use pallet_avn::{self as avn, AccountToBytesConverter, Error as avn_error};
@@ -463,16 +463,21 @@ impl<T: Config> Pallet<T> {
         if candidate_tx.ready_to_dispatch() {
             if <DispatchedAvnTxIds<T>>::contains_key(&submitter) {
                 <DispatchedAvnTxIds<T>>::mutate(&submitter, |submitter_dispatched_tx| {
-                    submitter_dispatched_tx.try_push(DispatchedData::new(
-                        candidate_tx_id,
-                        <system::Pallet<T>>::block_number(),
-                    )).map_err(|_| Error::<T>::TransactionIdLimitReached)?;
+                    submitter_dispatched_tx
+                        .try_push(DispatchedData::new(
+                            candidate_tx_id,
+                            <system::Pallet<T>>::block_number(),
+                        ))
+                        .map_err(|_| Error::<T>::TransactionIdLimitReached)?;
                     Ok(())
                 })?;
             } else {
                 <DispatchedAvnTxIds<T>>::insert(
                     &submitter,
-                    BoundedVec::truncate_from(vec![DispatchedData::new(candidate_tx_id, <system::Pallet<T>>::block_number())]),
+                    BoundedVec::truncate_from(vec![DispatchedData::new(
+                        candidate_tx_id,
+                        <system::Pallet<T>>::block_number(),
+                    )]),
                 );
             }
             Self::deposit_event(Event::<T>::TransactionReadyToSend {

--- a/pallets/ethereum-transactions/src/lib.rs
+++ b/pallets/ethereum-transactions/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 
 use codec::{Decode, Encode, MaxEncodedLen};
+use ethereum_transaction::SignaturesLimit;
 use frame_support::{dispatch::DispatchResult, ensure, log, traits::Get};
 use frame_system::{
     self as system, ensure_none, ensure_root,
@@ -631,7 +632,7 @@ pub trait CandidateTransactionSubmitter<AccountId> {
         candidate_type: EthTransactionType,
         tx_id: TransactionId,
         submitter: AccountId,
-        signatures: Vec<ecdsa::Signature>,
+        signatures: BoundedVec<ecdsa::Signature, SignaturesLimit>,
     ) -> DispatchResult;
 
     /// Sets a transaction Id. This is only enabled for benchmarks
@@ -662,7 +663,7 @@ impl<T: Config> CandidateTransactionSubmitter<T::AccountId> for Pallet<T> {
         candidate_type: EthTransactionType,
         tx_id: TransactionId,
         submitter: T::AccountId,
-        signatures: Vec<ecdsa::Signature>,
+        signatures: BoundedVec<ecdsa::Signature, SignaturesLimit>,
     ) -> DispatchResult {
         ensure!(
             <ReservedTransactions<T>>::contains_key(&candidate_type),

--- a/pallets/ethereum-transactions/src/mock.rs
+++ b/pallets/ethereum-transactions/src/mock.rs
@@ -179,12 +179,14 @@ impl EthereumTransactions {
         submitter: AccountId,
         candidate_transaction_ids: Vec<TransactionId>,
     ) {
+        let dispatched_data_vec: Vec<DispatchedData<TransactionId>> = candidate_transaction_ids
+            .iter()
+            .map(|id| DispatchedData::new(*id, 0u64))
+            .collect();
+    
         <EthereumTransactions as Store>::DispatchedAvnTxIds::insert(
             submitter,
-            candidate_transaction_ids
-                .iter()
-                .map(|id| DispatchedData::new(*id, 0u64))
-                .collect::<Vec<_>>(),
+            BoundedVec::truncate_from(dispatched_data_vec),
         );
     }
 

--- a/pallets/ethereum-transactions/src/mock.rs
+++ b/pallets/ethereum-transactions/src/mock.rs
@@ -183,7 +183,7 @@ impl EthereumTransactions {
             .iter()
             .map(|id| DispatchedData::new(*id, 0u64))
             .collect();
-    
+
         <EthereumTransactions as Store>::DispatchedAvnTxIds::insert(
             submitter,
             BoundedVec::truncate_from(dispatched_data_vec),

--- a/pallets/ethereum-transactions/src/tests/tests.rs
+++ b/pallets/ethereum-transactions/src/tests/tests.rs
@@ -225,7 +225,10 @@ impl DefaultTransactionBuilder {
             self.tx_type.clone(),
             Self::default_quorum(),
         );
-        tx_candidate.signatures.append(self.confirmations.clone());
+        tx_candidate
+            .signatures
+            .append(self.confirmations.clone())
+            .expect("Exceeded signature limit");
 
         return tx_candidate
     }

--- a/pallets/ethereum-transactions/src/tests/tests.rs
+++ b/pallets/ethereum-transactions/src/tests/tests.rs
@@ -49,7 +49,9 @@ fn generate_merkle_root_mock_data_with_signatures(
 ) -> (AccountId, [u8; 32], EthSignatures, EthTransactionCandidate) {
     let (from, root_hash, mut sigs, mut candidate_transaction) =
         generate_merkle_root_mock_data_with_sender();
-    sigs.signatures_list.append(&mut create_mock_ecdsa_signatures());
+    sigs.signatures_list
+        .try_append(&mut create_mock_ecdsa_signatures())
+        .expect("Cannot append signatures");
     candidate_transaction.signatures = sigs.clone();
     return (from, root_hash, sigs, candidate_transaction)
 }
@@ -65,7 +67,9 @@ fn generate_merkle_root_mock_data_with_sender(
 fn generate_deregister_validator_mock_data_with_signatures() -> EthTransactionCandidate {
     let (mut sigs, mut candidate_transaction) =
         generate_deregister_validator_mock_data_with_sender();
-    sigs.signatures_list.append(&mut create_mock_ecdsa_signatures());
+    sigs.signatures_list
+        .try_append(&mut create_mock_ecdsa_signatures())
+        .expect("Cannot append signatures");
     candidate_transaction.signatures = sigs.clone();
     return candidate_transaction
 }

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -1188,7 +1188,7 @@ pub mod pallet {
                             )),
                             *root_data.tx_id.as_ref().expect("Non empty roots have valid hash"),
                             root_data.added_by.ok_or(Error::<T>::CurrentSlotValidatorNotFound)?,
-                            voting_session.state()?.confirmations.to_vec(),
+                            voting_session.state()?.confirmations,
                         );
 
                     if let Err(result) = result {

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -9,7 +9,9 @@ use pallet_avn::{
 };
 use pallet_session as session;
 use parking_lot::RwLock;
-use sp_avn_common::{safe_add_block_numbers, safe_sub_block_numbers};
+use sp_avn_common::{
+    bounds::MaximumValidatorsBound, safe_add_block_numbers, safe_sub_block_numbers,
+};
 use sp_core::{
     ecdsa,
     offchain::{
@@ -352,7 +354,7 @@ impl CandidateTransactionSubmitter<AccountId> for TestRuntime {
         candidate_type: EthTransactionType,
         _tx_id: TransactionId,
         _submitter: AccountId,
-        _signatures: Vec<ecdsa::Signature>,
+        _signatures: BoundedVec<ecdsa::Signature, MaximumValidatorsBound>,
     ) -> DispatchResult {
         if candidate_type !=
             EthTransactionType::PublishRoot(PublishRootData::new(

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -679,7 +679,7 @@ impl<T: Config> Pallet<T> {
                 validators_action_data.reserved_eth_transaction,
                 validators_action_data.eth_transaction_id,
                 validators_action_data.primary_validator,
-                voting_session.state()?.confirmations.to_vec(),
+                voting_session.state()?.confirmations,
             );
 
             if let Err(result) = result {

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -359,7 +359,7 @@ impl CandidateTransactionSubmitter<AccountId> for TestRuntime {
         _candidate_type: EthTransactionType,
         _tx_id: TransactionId,
         _submitter: AccountId,
-        _signatures: Vec<ecdsa::Signature>,
+        _signatures: BoundedVec<ecdsa::Signature, MaximumValidatorsBound>,
     ) -> DispatchResult {
         Ok(())
     }

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 39,
+    spec_version: 40,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 39,
+    spec_version: 40,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

converted ethereum-transactions-pallet to use BoundedVec for the number of its validators

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [x] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [x] Business logic tested successfully
- [x] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.


