### PR TITLE
SYS-3338 make nft manager storage items bounded (2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-finality-tracker"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-transactions"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "3.1.2"
+version = "3.2.0"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7055,6 +7055,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
+ "log",
  "pallet-avn",
  "parity-scale-codec 3.2.1",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "3.1.2"
+version = "3.2.0"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/node/src/chain_spec/stable/mod.rs
+++ b/node/src/chain_spec/stable/mod.rs
@@ -103,6 +103,7 @@ pub(crate) fn testnet_genesis(
         aura: Default::default(),
         aura_ext: Default::default(),
         im_online: ImOnlineConfig { keys: vec![] },
+        nft_manager: Default::default(),
         parachain_system: Default::default(),
         parachain_staking: ParachainStakingConfig {
             candidates: candidates

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -6,7 +6,7 @@ use frame_system as system;
 use hex_literal::hex;
 use pallet_balances;
 use pallet_nft_manager::nft_data::Royalty;
-use sp_core::{sr25519, Pair, H160, H256};
+use sp_core::{sr25519, ConstU32, Pair, H160, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::{Header, UintAuthorityId},
@@ -113,6 +113,7 @@ impl pallet_nft_manager::Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = ConstU32<10>;
 }
 
 impl pallet_avn::Config for TestRuntime {

--- a/pallets/avn/src/vote.rs
+++ b/pallets/avn/src/vote.rs
@@ -12,7 +12,10 @@ use frame_support::{
     ensure,
 };
 use sp_application_crypto::RuntimeAppPublic;
-use sp_avn_common::{event_types::Validator, MaximumValidatorsBound, VotingSessionIdBound};
+use sp_avn_common::{
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    event_types::Validator,
+};
 use sp_core::ecdsa;
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/nft-manager/Cargo.toml
+++ b/pallets/nft-manager/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+log = { version = "0.4.17", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 hex-literal = { version = "0.3.4", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
@@ -47,6 +48,7 @@ std = [
     'frame-system/std',
     'pallet-avn/std',
     'sp-avn-common/std',
+    'log/std',
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/nft-manager/src/batch_nft.rs
+++ b/pallets/nft-manager/src/batch_nft.rs
@@ -16,12 +16,14 @@
 
 use crate::{
     keccak_256, BatchInfoId, BatchOpenForSale, Config, Decode, DispatchResult, Encode, Error,
-    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftInfo, NftInfoId,
-    NftInfos, NftSaleType, NftUniqueId, Nfts, Pallet, ProcessedEventsChecker, Proof, Royalty, Vec,
-    BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160, U256,
+    EthEventId, Event, Nft, NftBatchId, NftBatches, NftEndBatchListingData, NftExternalRefBound,
+    NftInfo, NftInfoId, NftInfos, NftRoyaltiesBound, NftSaleType, NftUniqueId, Nfts, Pallet,
+    ProcessedEventsChecker, Proof, Royalty, Vec, BATCH_ID_CONTEXT, BATCH_NFT_ID_CONTEXT, H160,
+    U256,
 };
 use frame_support::{dispatch::DispatchError, ensure};
 use sp_avn_common::event_types::NftMintData;
+use sp_core::bounded::BoundedVec;
 
 pub const SIGNED_CREATE_BATCH_CONTEXT: &'static [u8] = b"authorization for create batch operation";
 pub const SIGNED_MINT_BATCH_NFT_CONTEXT: &'static [u8] =
@@ -69,7 +71,7 @@ pub fn get_nft_info_for_batch<T: Config>(
 pub fn create_batch<T: Config>(
     info_id: NftInfoId,
     batch_id: NftBatchId,
-    royalties: Vec<Royalty>,
+    royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
     total_supply: u64,
     t1_authority: H160,
     creator: T::AccountId,
@@ -149,12 +151,17 @@ pub fn process_mint_batch_nft_event<T: Config>(
     let owner = T::AccountId::decode(&mut data.t2_owner_public_key.as_bytes())
         .expect("32 bytes will always decode into an AccountId");
 
-    Ok(mint_batch_nft::<T>(data.batch_id, owner, data.sale_index, &data.unique_external_ref)?)
+    Ok(mint_batch_nft::<T>(
+        data.batch_id,
+        owner,
+        data.sale_index,
+        data.unique_external_ref.clone(),
+    )?)
 }
 
 pub fn validate_mint_batch_nft_request<T: Config>(
     batch_id: NftBatchId,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
 ) -> Result<NftInfo<T::AccountId>, DispatchError> {
     ensure!(batch_id.is_zero() == false, Error::<T>::BatchIdIsMandatory);
     ensure!(<BatchInfoId<T>>::contains_key(&batch_id), Error::<T>::BatchDoesNotExist);
@@ -175,17 +182,17 @@ pub fn mint_batch_nft<T: Config>(
     batch_id: NftBatchId,
     owner: T::AccountId,
     sale_index: u64,
-    unique_external_ref: &Vec<u8>,
+    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
 ) -> DispatchResult {
-    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, unique_external_ref)?;
+    let nft_info = validate_mint_batch_nft_request::<T>(batch_id, &unique_external_ref)?;
     let nft_id = generate_batch_nft_id::<T>(&batch_id, &sale_index);
     ensure!(<Nfts<T>>::contains_key(&nft_id) == false, Error::<T>::NftAlreadyExists);
 
-    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref.to_vec(), owner.clone());
-    Pallet::<T>::add_nft_and_update_owner(&owner, &nft);
+    let nft = Nft::new(nft_id, nft_info.info_id, unique_external_ref, owner.clone());
+    Pallet::<T>::add_nft(&nft);
 
     let mut nfts_for_batch = <NftBatches<T>>::get(batch_id);
-    nfts_for_batch.push(nft_id);
+    nfts_for_batch.try_push(nft_id).map_err(|_| Error::<T>::BatchOutOfBounds)?;
     <NftBatches<T>>::insert(batch_id, nfts_for_batch);
 
     <crate::Pallet<T>>::deposit_event(Event::<T>::BatchNftMinted {

--- a/pallets/nft-manager/src/lib.rs
+++ b/pallets/nft-manager/src/lib.rs
@@ -25,7 +25,8 @@ use frame_support::{
         DispatchErrorWithPostInfo, DispatchResult, DispatchResultWithPostInfo, Dispatchable,
         PostDispatchInfo,
     },
-    ensure, log,
+    ensure,
+    pallet_prelude::StorageVersion,
     traits::{Get, IsSubType},
     weights::Weight,
     Parameter,
@@ -39,11 +40,12 @@ use sp_avn_common::{
     },
     verify_signature, CallDecoder, InnerCallValidator, Proof,
 };
-use sp_core::{H160, H256, U256};
+use sp_core::{ConstU32, H160, H256, U256};
 use sp_io::hashing::keccak_256;
 use sp_runtime::{
     scale_info::TypeInfo,
     traits::{Hash, IdentifyAccount, Member, Verify},
+    BoundedVec, WeakBoundedVec,
 };
 use sp_std::prelude::*;
 
@@ -72,12 +74,17 @@ pub const SIGNED_CANCEL_LIST_FIAT_NFT_CONTEXT: &'static [u8] =
 pub const SIGNED_MINT_BATCH_NFT_CONTEXT: &'static [u8] =
     b"authorization for mint batch nft operation";
 
-const MAX_NUMBER_OF_ROYALTIES: u32 = 5;
+const MAX_NUMBER_OF_ROYALTIES: u32 = 16;
+/// Bound used for number of Royalties an NFTs that can have
+pub(crate) type NftRoyaltiesBound = ConstU32<MAX_NUMBER_OF_ROYALTIES>;
 
 pub type NftId = U256;
 pub type NftInfoId = U256;
 pub type NftBatchId = U256;
 pub type NftUniqueId = U256;
+
+/// Suggested bound to use in runtime for number of NFTs that can exist in a single Batch
+pub type BatchNftBound = ConstU32<16384>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -111,11 +118,33 @@ pub mod pallet {
             + TypeInfo;
 
         type WeightInfo: WeightInfo;
+
+        #[pallet::constant]
+        type BatchBound: Get<u32>;
+    }
+
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub _phantom: sp_std::marker::PhantomData<T>,
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self { _phantom: Default::default() }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            crate::STORAGE_VERSION.put::<Pallet<T>>();
+        }
     }
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
-    #[pallet::without_storage_info]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(_);
 
     #[pallet::event]
@@ -242,6 +271,12 @@ pub mod pallet {
         UnauthorizedSignedEndBatchSaleTransaction,
         BatchNotListedForFiatSale,
         BatchNotListedForEthereumSale,
+        /// External reference size is out of bounds
+        ExternalRefOutOfBounds,
+        /// Nft Royalties size is out of bounds
+        RoyaltiesOutOfBounds,
+        /// Batch size is out of bounds
+        BatchOutOfBounds,
     }
 
     /// A mapping between NFT Id and data
@@ -260,7 +295,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn nft_batches)]
     pub type NftBatches<T: Config> =
-        StorageMap<_, Blake2_128Concat, NftBatchId, Vec<NftId>, ValueQuery>;
+        StorageMap<_, Blake2_128Concat, NftBatchId, BoundedVec<NftId, T::BatchBound>, ValueQuery>;
 
     /// A mapping between the external batch id and its corresponding NtfInfoId
     #[pallet::storage]
@@ -268,11 +303,12 @@ pub mod pallet {
     pub type BatchInfoId<T: Config> =
         StorageMap<_, Blake2_128Concat, NftBatchId, NftInfoId, ValueQuery>;
 
+    /// TODO: convert the key to BoundedVec once a runtime with the storage migration is applied.
     /// A mapping between an ExternalRef and a flag to show that an NFT has used it
     #[pallet::storage]
     #[pallet::getter(fn is_external_ref_used)]
     pub type UsedExternalReferences<T: Config> =
-        StorageMap<_, Blake2_128Concat, Vec<u8>, bool, ValueQuery>;
+        StorageMap<_, Blake2_128Concat, WeakBoundedVec<u8, NftExternalRefBound>, bool, ValueQuery>;
 
     /// The Id that will be used when creating the new NftInfo record
     #[pallet::storage]
@@ -290,16 +326,6 @@ pub mod pallet {
     #[pallet::getter(fn get_nft_open_for_sale_on)]
     pub type NftOpenForSale<T: Config> =
         StorageMap<_, Blake2_128Concat, NftId, NftSaleType, ValueQuery>;
-
-    /// A mapping between the external batch id and its nft Ids
-    #[pallet::storage]
-    #[pallet::getter(fn get_owned_nfts)]
-    pub type OwnedNfts<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::AccountId, Vec<NftId>, ValueQuery>;
-
-    /// The version of this storage
-    #[pallet::storage]
-    pub type StorageVersion<T: Config> = StorageValue<_, Releases, ValueQuery>;
 
     /// An account nonce that represents the number of proxy transactions from this account
     #[pallet::storage]
@@ -325,7 +351,15 @@ pub mod pallet {
             t1_authority: H160,
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            Self::validate_mint_single_nft_request(&unique_external_ref, &royalties, t1_authority)?;
+
+            let bounded_unique_external_ref =
+                BoundedVec::<u8, NftExternalRefBound>::try_from(unique_external_ref)
+                    .map_err(|_| Error::<T>::ExternalRefOutOfBounds)?;
+            Self::validate_mint_single_nft_request(
+                &bounded_unique_external_ref,
+                &royalties,
+                t1_authority,
+            )?;
 
             // We trust the input for the value of t1_authority
             let nft_id =
@@ -336,10 +370,10 @@ pub mod pallet {
             let info_id = Self::get_info_id_and_advance();
             let (nft, info) = Self::insert_single_nft_into_chain(
                 info_id,
-                royalties,
+                BoundedVec::try_from(royalties).map_err(|_| Error::<T>::RoyaltiesOutOfBounds)?,
                 t1_authority,
                 nft_id,
-                unique_external_ref,
+                bounded_unique_external_ref,
                 sender,
             );
 
@@ -364,7 +398,14 @@ pub mod pallet {
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             ensure!(sender == proof.signer, Error::<T>::SenderIsNotSigner);
-            Self::validate_mint_single_nft_request(&unique_external_ref, &royalties, t1_authority)?;
+            let bounded_unique_external_ref =
+                BoundedVec::<u8, NftExternalRefBound>::try_from(unique_external_ref.clone())
+                    .map_err(|_| Error::<T>::ExternalRefOutOfBounds)?;
+            Self::validate_mint_single_nft_request(
+                &bounded_unique_external_ref,
+                &royalties,
+                t1_authority,
+            )?;
 
             let signed_payload = Self::encode_mint_single_nft_params(
                 &proof,
@@ -387,10 +428,10 @@ pub mod pallet {
             let info_id = Self::get_info_id_and_advance();
             let (nft, info) = Self::insert_single_nft_into_chain(
                 info_id,
-                royalties,
+                BoundedVec::try_from(royalties).map_err(|_| Error::<T>::RoyaltiesOutOfBounds)?,
                 t1_authority,
                 nft_id,
-                unique_external_ref,
+                bounded_unique_external_ref,
                 proof.signer,
             );
 
@@ -474,7 +515,7 @@ pub mod pallet {
                 .expect("32 bytes will always decode into an AccountId");
             let market = Self::get_nft_open_for_sale_on(nft_id);
 
-            Self::transfer_nft(&nft_id, &nft.owner, &new_nft_owner.clone())?;
+            Self::transfer_nft(&nft_id, &new_nft_owner.clone())?;
             Self::deposit_event(Event::<T>::FiatNftTransfer {
                 nft_id,
                 sender,
@@ -561,6 +602,7 @@ pub mod pallet {
             ensure!(sender == proof.signer, Error::<T>::SenderIsNotSigner);
             ensure!(t1_authority.is_zero() == false, Error::<T>::T1AuthorityIsMandatory);
             ensure!(total_supply > 0u64, Error::<T>::TotalSupplyZero);
+            ensure!(total_supply <= T::BatchBound::get().into(), Error::<T>::BatchOutOfBounds);
 
             Self::validate_royalties(&royalties)?;
 
@@ -589,7 +631,7 @@ pub mod pallet {
             create_batch::<T>(
                 info_id,
                 batch_id,
-                royalties,
+                BoundedVec::try_from(royalties).map_err(|_| Error::<T>::RoyaltiesOutOfBounds)?,
                 total_supply,
                 t1_authority,
                 sender.clone(),
@@ -621,7 +663,11 @@ pub mod pallet {
             let sender = ensure_signed(origin)?;
             ensure!(sender == proof.signer, Error::<T>::SenderIsNotSigner);
 
-            let nft_info = validate_mint_batch_nft_request::<T>(batch_id, &unique_external_ref)?;
+            let bounded_unique_external_ref =
+                BoundedVec::<u8, NftExternalRefBound>::try_from(unique_external_ref)
+                    .map_err(|_| Error::<T>::ExternalRefOutOfBounds)?;
+            let nft_info =
+                validate_mint_batch_nft_request::<T>(batch_id, &bounded_unique_external_ref)?;
             ensure!(
                 <BatchOpenForSale<T>>::get(&batch_id) == NftSaleType::Fiat,
                 Error::<T>::BatchNotListedForFiatSale
@@ -632,7 +678,7 @@ pub mod pallet {
                 &proof,
                 &batch_id,
                 &index,
-                &unique_external_ref,
+                &bounded_unique_external_ref,
                 &owner,
             );
             ensure!(
@@ -641,7 +687,7 @@ pub mod pallet {
                 Error::<T>::UnauthorizedSignedMintBatchNftTransaction
             );
 
-            mint_batch_nft::<T>(batch_id, owner, index, &unique_external_ref)?;
+            mint_batch_nft::<T>(batch_id, owner, index, bounded_unique_external_ref)?;
 
             Ok(())
         }
@@ -734,11 +780,66 @@ pub mod pallet {
         // migration logic should be done in a separate function so it can be tested
         // properly.
         fn on_runtime_upgrade() -> Weight {
-            if <StorageVersion<T>>::get() == Releases::V2_0_0 {
-                <StorageVersion<T>>::put(Releases::V3_0_0);
-                return migrations::migrate_to_batch_nft::<T>()
-            }
+            let onchain_version = Pallet::<T>::on_chain_storage_version();
 
+            log::debug!(
+                "Nft manager storage chain/current storage version: {:?} / {:?}",
+                onchain_version,
+                Pallet::<T>::current_storage_version(),
+            );
+
+            if onchain_version < 4 {
+                use frame_support::storage::unhashed;
+
+                // Owned Nfts cleanup
+                {
+                    let owned_nfts_prefix = storage::storage_prefix(b"NftManager", b"OwnedNfts");
+                    let mut key = vec![0u8; 32];
+                    key[0..32].copy_from_slice(&owned_nfts_prefix);
+                    let res = unhashed::clear_prefix(&key[0..32], None, None);
+
+                    log::info!(
+                    "✅ Cleared '{}' backend values from 'NftManager::OwnedNfts' storage prefix",
+                        res.backend
+                    );
+                    log::info!(
+                        "✅ Cleared '{}' entries from 'NftManager::OwnedNfts' storage prefix",
+                        res.unique
+                    );
+                    if res.maybe_cursor.is_some() {
+                        log::error!(
+                            "Storage prefix 'NftManager::OwnedNfts' is not completely cleared."
+                        );
+                    }
+                }
+                // Version item cleanup
+                {
+                    let storage_version_prefix =
+                        storage::storage_prefix(b"NftManager", b"StorageVersion");
+                    let mut key = vec![0u8; 32];
+                    key[0..32].copy_from_slice(&storage_version_prefix);
+                    let res = unhashed::clear_prefix(&key[0..32], None, None);
+
+                    log::info!(
+                    "✅ Cleared '{}' backend values from 'NftManager::StorageVersion' storage prefix",
+                        res.backend
+                    );
+                    log::info!(
+                        "✅ Cleared '{}' entries from 'NftManager::StorageVersion' storage prefix",
+                        res.unique
+                    );
+                    if res.maybe_cursor.is_some() {
+                        log::error!("Storage prefix 'StorageVersion' is not completely cleared.");
+                    }
+                }
+                crate::STORAGE_VERSION.put::<Pallet<T>>();
+                log::info!(
+                    "Dropped old enum-based versioning schema for nft-manager. New version:{:?}",
+                    Pallet::<T>::on_chain_storage_version()
+                );
+
+                return migrations::migrate_to_bounded_nft::<T>()
+            }
             return Weight::from_ref_time(0)
         }
     }
@@ -746,7 +847,7 @@ pub mod pallet {
 
 impl<T: Config> Pallet<T> {
     fn validate_mint_single_nft_request(
-        unique_external_ref: &Vec<u8>,
+        unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
         royalties: &Vec<Royalty>,
         t1_authority: H160,
     ) -> DispatchResult {
@@ -758,10 +859,16 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    fn validate_external_ref(unique_external_ref: &Vec<u8>) -> DispatchResult {
+    fn validate_external_ref(
+        unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
+    ) -> DispatchResult {
         ensure!(unique_external_ref.len() > 0, Error::<T>::ExternalRefIsMandatory);
+        let unique_reference = WeakBoundedVec::<u8, NftExternalRefBound>::force_from(
+            unique_external_ref.to_vec(),
+            Some("Weak bound exceeded. Shouldn't be possible when converting from bounded data."),
+        );
         ensure!(
-            Self::is_external_ref_used(&unique_external_ref) == false,
+            Self::is_external_ref_used(unique_reference) == false,
             Error::<T>::ExternalRefIsAlreadyInUse
         );
 
@@ -828,10 +935,10 @@ impl<T: Config> Pallet<T> {
 
     fn insert_single_nft_into_chain(
         info_id: NftInfoId,
-        royalties: Vec<Royalty>,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
         t1_authority: H160,
         nft_id: NftId,
-        unique_external_ref: Vec<u8>,
+        unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
         owner: T::AccountId,
     ) -> (Nft<T::AccountId>, NftInfo<T::AccountId>) {
         let info = NftInfo::new(info_id, royalties, t1_authority);
@@ -839,7 +946,7 @@ impl<T: Config> Pallet<T> {
 
         <NftInfos<T>>::insert(info.info_id, &info);
 
-        Self::add_nft_and_update_owner(&owner, &nft);
+        Self::add_nft(&nft);
         return (nft, info)
     }
 
@@ -884,7 +991,7 @@ impl<T: Config> Pallet<T> {
 
         let new_nft_owner = T::AccountId::decode(&mut data.t2_transfer_to_public_key.as_bytes())
             .expect("32 bytes will always decode into an AccountId");
-        Self::transfer_nft(&data.nft_id, &nft.owner, &new_nft_owner)?;
+        Self::transfer_nft(&data.nft_id, &new_nft_owner)?;
         Self::deposit_event(Event::<T>::EthNftTransfer {
             nft_id: data.nft_id,
             new_owner: new_nft_owner,
@@ -896,58 +1003,32 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    fn transfer_nft(
-        nft_id: &NftId,
-        old_nft_owner: &T::AccountId,
-        new_nft_owner: &T::AccountId,
-    ) -> DispatchResult {
+    fn transfer_nft(nft_id: &NftId, new_nft_owner: &T::AccountId) -> DispatchResult {
         Self::remove_listing_from_open_for_sale(nft_id)?;
-        Self::update_owner_for_transfer(nft_id, old_nft_owner, new_nft_owner);
+        Self::update_owner_for_transfer(nft_id, new_nft_owner);
         Ok(())
     }
 
     // See https://github.com/Aventus-Network-Services/avn-tier2/pull/991#discussion_r832470480 for details of why we have this
     // as a separate function
-    fn update_owner_for_transfer(
-        nft_id: &NftId,
-        old_nft_owner: &T::AccountId,
-        new_nft_owner: &T::AccountId,
-    ) {
+    fn update_owner_for_transfer(nft_id: &NftId, new_nft_owner: &T::AccountId) {
         <Nfts<T>>::mutate(nft_id, |maybe_nft| {
             maybe_nft.as_mut().map(|nft| {
                 nft.owner = new_nft_owner.clone();
                 nft.nonce += 1u64;
             })
         });
-
-        <OwnedNfts<T>>::mutate(old_nft_owner, |owner_nfts| {
-            if let Some(pos) = owner_nfts.iter().position(|n| n == nft_id) {
-                owner_nfts.swap_remove(pos);
-            }
-        });
-
-        if <OwnedNfts<T>>::contains_key(new_nft_owner) {
-            <OwnedNfts<T>>::mutate(new_nft_owner, |owner_nfts| {
-                owner_nfts.push(*nft_id);
-            });
-        } else {
-            <OwnedNfts<T>>::insert(new_nft_owner, vec![*nft_id]);
-        }
     }
 
     // See https://github.com/Aventus-Network-Services/avn-tier2/pull/991#discussion_r832470480 for details of why we have this
     // as a separate function
-    fn add_nft_and_update_owner(owner: &T::AccountId, nft: &Nft<T::AccountId>) {
+    fn add_nft(nft: &Nft<T::AccountId>) {
         <Nfts<T>>::insert(nft.nft_id, &nft);
-        <UsedExternalReferences<T>>::insert(&nft.unique_external_ref, true);
-
-        if <OwnedNfts<T>>::contains_key(owner) {
-            <OwnedNfts<T>>::mutate(owner, |owner_nfts| {
-                owner_nfts.push(nft.nft_id);
-            });
-        } else {
-            <OwnedNfts<T>>::insert(owner, vec![nft.nft_id]);
-        }
+        let unique_reference = WeakBoundedVec::<u8, NftExternalRefBound>::force_from(
+            nft.unique_external_ref.to_vec(),
+            Some("Weak bound exceeded. Shouldn't be possible when converting from bounded data."),
+        );
+        <UsedExternalReferences<T>>::insert(&unique_reference, true);
     }
 
     fn cancel_eth_nft_listing(
@@ -1227,57 +1308,70 @@ impl<T: Config> InnerCallValidator for Pallet<T> {
     }
 }
 
-// A value placed in storage that represents the current version of the Staking storage. This value
-// is used by the `on_runtime_upgrade` logic to determine whether we run storage migration logic.
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, MaxEncodedLen, TypeInfo)]
-pub enum Releases {
-    Unknown,
-    V2_0_0,
-    V3_0_0,
-}
-
-impl Default for Releases {
-    fn default() -> Self {
-        Releases::V3_0_0
-    }
-}
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
 
 pub mod migrations {
     use super::*;
 
     #[derive(Decode)]
-    struct OldNftInfo {
+    pub struct OldNft<AccountId: Member> {
+        pub nft_id: NftId,
         pub info_id: NftInfoId,
-        pub batch_id: Option<NftBatchId>,
-        pub royalties: Vec<Royalty>,
-        pub total_supply: u64,
-        pub t1_authority: H160,
+        pub unique_external_ref: Vec<u8>,
+        pub nonce: u64,
+        pub owner: AccountId,
+        pub is_locked: bool,
     }
 
-    impl OldNftInfo {
-        fn upgraded<T: Config>(self) -> NftInfo<T::AccountId> {
-            NftInfo {
+    impl<AccountId: Member> OldNft<AccountId> {
+        fn upgraded(self) -> Nft<AccountId> {
+            Nft::<AccountId> {
+                nft_id: self.nft_id,
                 info_id: self.info_id,
-                batch_id: self.batch_id,
-                royalties: self.royalties,
-                total_supply: self.total_supply,
-                t1_authority: self.t1_authority,
-                creator: None,
+                unique_external_ref: BoundedVec::truncate_from(self.unique_external_ref),
+                nonce: self.nonce,
+                owner: self.owner,
+                is_locked: self.is_locked,
             }
         }
     }
 
-    pub fn migrate_to_batch_nft<T: Config>() -> frame_support::weights::Weight {
+    pub fn migrate_to_bounded_nft<T: Config>() -> frame_support::weights::Weight {
         sp_runtime::runtime_logger::RuntimeLogger::init();
         log::info!("ℹ️  Nft manager pallet data migration invoked");
 
-        NftInfos::<T>::translate::<OldNftInfo, _>(|_, p| Some(p.upgraded::<T>()));
+        let mut keys_need_update = Vec::<Vec<u8>>::new();
+        let bound: usize = <NftExternalRefBound as sp_core::Get<u32>>::get() as usize;
 
-        log::info!("ℹ️  Migrated NftInfo data successfully");
+        Nfts::<T>::translate::<OldNft<T::AccountId>, _>(|_, p| {
+            if p.unique_external_ref.len() > bound {
+                keys_need_update.push(p.unique_external_ref.clone());
+            }
+            Some(p.upgraded())
+        });
+
+        log::info!("ℹ️ Found {:?} out of bounds external ref. Migrating...", keys_need_update.len());
+
+        for external_ref in keys_need_update.iter() {
+            let unique_reference = WeakBoundedVec::<u8, NftExternalRefBound>::force_from(
+                external_ref.clone(),
+                Some("Weak bound exceeded. Expected when migrating data to bounded"),
+            );
+            let value = UsedExternalReferences::<T>::get(&unique_reference);
+            UsedExternalReferences::<T>::remove(unique_reference);
+            let new_unique_reference = WeakBoundedVec::<u8, NftExternalRefBound>::force_from(
+                BoundedVec::<u8, NftExternalRefBound>::truncate_from(external_ref.clone()).to_vec(),
+                Some(
+                    "Weak bound exceeded. Shouldn't be possible when converting from bounded data.",
+                ),
+            );
+            UsedExternalReferences::<T>::insert(new_unique_reference, value)
+        }
+
+        log::info!("ℹ️  Migrated Nfts bounds applied successfully");
         return T::BlockWeights::get().max_block
     }
 }
-
 #[cfg(test)]
 #[path = "tests/mock.rs"]
 mod mock;

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -15,8 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
+use sp_core::bounded::BoundedVec;
 use sp_runtime::traits::Member;
 
+pub(crate) use sp_avn_common::bounds::NftExternalRefBound;
 pub const ROYALTY_RATE_DENOMINATOR: u32 = 1_000_000;
 
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq, MaxEncodedLen, TypeInfo)]
@@ -39,14 +41,14 @@ impl RoyaltyRate {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct Nft<AccountId: Member> {
     /// Unique identifier of a nft
     pub nft_id: NftId,
     /// Id of an info struct instance
     pub info_id: NftInfoId,
     /// Unique reference to the NFT asset stored off-chain
-    pub unique_external_ref: Vec<u8>,
+    pub unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
     /// Transfer nonce of this NFT
     pub nonce: u64,
     /// Owner account address of this NFT
@@ -61,7 +63,7 @@ impl<AccountId: Member> Nft<AccountId> {
     pub fn new(
         nft_id: NftId,
         info_id: NftInfoId,
-        unique_external_ref: Vec<u8>,
+        unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
         owner: AccountId,
     ) -> Self {
         return Nft::<AccountId> {
@@ -75,14 +77,14 @@ impl<AccountId: Member> Nft<AccountId> {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct NftInfo<AccountId: Member> {
     /// Unique identifier of this information
     pub info_id: NftInfoId,
     /// Batch Id defined by client
     pub batch_id: Option<NftBatchId>,
     /// Royalties payment rate for the nft.
-    pub royalties: Vec<Royalty>,
+    pub royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
     /// Total supply of NFTs in this collection:
     ///  - 1: it is for a singleton
     ///  - >1: it is for a batch
@@ -95,7 +97,11 @@ pub struct NftInfo<AccountId: Member> {
 }
 
 impl<AccountId: Member> NftInfo<AccountId> {
-    pub fn new(info_id: NftInfoId, royalties: Vec<Royalty>, t1_authority: H160) -> Self {
+    pub fn new(
+        info_id: NftInfoId,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
+        t1_authority: H160,
+    ) -> Self {
         return NftInfo::<AccountId> {
             info_id,
             batch_id: None,
@@ -109,7 +115,7 @@ impl<AccountId: Member> NftInfo<AccountId> {
     pub fn new_batch(
         info_id: NftInfoId,
         batch_id: NftBatchId,
-        royalties: Vec<Royalty>,
+        royalties: BoundedVec<Royalty, NftRoyaltiesBound>,
         t1_authority: H160,
         total_supply: u64,
         creator: AccountId,

--- a/pallets/nft-manager/src/tests/batch_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/batch_nft_tests.rs
@@ -215,6 +215,53 @@ mod signed_create_batch {
         }
 
         #[test]
+        fn total_supply_exceeds_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context = CreateBatchContext::default();
+                let out_of_bounds_supply: u32 = <MockNftBatchBound as sp_core::Get<u32>>::get() + 1;
+
+                context.total_supply = out_of_bounds_supply as u64;
+
+                let nonce = <BatchNonces<TestRuntime>>::get(context.creator_account);
+                let inner_call = context.create_signed_create_batch_call(nonce);
+
+                assert_noop!(
+                    NftManager::proxy(Origin::signed(context.relayer), inner_call),
+                    Error::<TestRuntime>::BatchOutOfBounds
+                );
+            });
+        }
+
+        #[test]
+        fn royalties_exceeds_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context = CreateBatchContext::default();
+                let out_of_bounds_royalties: u32 =
+                    <NftRoyaltiesBound as sp_core::Get<u32>>::get() + 1;
+
+                context.royalties = vec![
+                    Royalty {
+                        recipient_t1_address: H160(hex!(
+                            "0000000000000000000000000000000000000002"
+                        )),
+                        rate: RoyaltyRate { parts_per_million: 1_000u32 },
+                    };
+                    out_of_bounds_royalties as usize
+                ];
+
+                let nonce = <BatchNonces<TestRuntime>>::get(context.creator_account);
+                let inner_call = context.create_signed_create_batch_call(nonce);
+
+                assert_noop!(
+                    NftManager::proxy(Origin::signed(context.relayer), inner_call),
+                    Error::<TestRuntime>::RoyaltiesOutOfBounds
+                );
+            });
+        }
+
+        #[test]
         fn t1_authority_is_empty() {
             let mut ext = ExtBuilder::build_default().as_externality();
             ext.execute_with(|| {
@@ -515,7 +562,10 @@ impl MintBatchNftContext {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.unique_external_ref);
+        <UsedExternalReferences<TestRuntime>>::remove(
+            &WeakBoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded."),
+        );
     }
 
     fn create_signed_mint_batch_nft_call(
@@ -587,9 +637,6 @@ mod signed_mint_batch_nft {
                 // Nft has been minted
                 assert_eq!(true, <Nfts<TestRuntime>>::contains_key(&context.nft_id));
 
-                // Ownership data is updated
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-
                 // Batch_id map has been created
                 assert!(<NftBatches<TestRuntime>>::contains_key(&batch_id));
 
@@ -603,7 +650,8 @@ mod signed_mint_batch_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.unique_external_ref
+                        WeakBoundedVec::try_from(context.unique_external_ref)
+                            .expect("Unique external reference bound was exceeded.")
                     )
                 );
 
@@ -641,22 +689,6 @@ mod signed_mint_batch_nft {
 
                 // 2 Nfts minted and assigned to the same batch
                 assert_eq!(<NftBatches<TestRuntime>>::get(batch_id).len(), 2);
-
-                // Ownership data is updated
-                assert_eq!(
-                    true,
-                    nft_is_owned(
-                        &context.nft_owner_account,
-                        &<NftBatches<TestRuntime>>::get(batch_id)[0]
-                    )
-                );
-                assert_eq!(
-                    true,
-                    nft_is_owned(
-                        &context.nft_owner_account,
-                        &<NftBatches<TestRuntime>>::get(batch_id)[1]
-                    )
-                );
             });
         }
     }
@@ -757,6 +789,28 @@ mod signed_mint_batch_nft {
                 assert_noop!(
                     NftManager::proxy(Origin::signed(context.relayer), inner_call),
                     Error::<TestRuntime>::ExternalRefIsMandatory
+                );
+            });
+        }
+
+        #[test]
+        fn external_ref_is_out_of_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context = MintBatchNftContext::default();
+                context.setup();
+
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
+
+                let index = 0u64;
+                let batch_id = create_batch_and_list();
+
+                let inner_call = context.create_signed_mint_batch_nft_call(batch_id, index);
+
+                assert_noop!(
+                    NftManager::proxy(Origin::signed(context.relayer), inner_call),
+                    Error::<TestRuntime>::ExternalRefOutOfBounds
                 );
             });
         }
@@ -1287,7 +1341,10 @@ mod signed_list_batch_for_sale {
                 for i in 0..info.total_supply {
                     nft_ids.push(U256::zero() + i);
                 }
-                <NftBatches<TestRuntime>>::insert(batch_id, nft_ids);
+                <NftBatches<TestRuntime>>::insert(
+                    batch_id,
+                    BoundedVec::try_from(nft_ids).expect("Batch boundaries were exceeded"),
+                );
 
                 // Now try to list the batch for sale
                 let inner_call = context.create_signed_list_batch_for_sale_call(batch_id, nonce);

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -84,16 +84,25 @@ mod cancel_single_nft_listing {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
         }
 
         pub fn cancel_nft_listing_data(&self) -> NftCancelListingData {
             return NftCancelListingData { nft_id: self.nft_id(), op_id: self.op_id }
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -19,7 +19,7 @@
 use frame_support::parameter_types;
 use frame_system as system;
 use sp_avn_common::event_types::EthEventId;
-use sp_core::{sr25519, Pair, H256};
+use sp_core::{sr25519, ConstU32, Pair, H256};
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
     testing::Header,
@@ -39,6 +39,7 @@ pub type Hashing = <TestRuntime as system::Config>::Hashing;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
+pub type MockNftBatchBound = ConstU32<8>;
 
 frame_support::construct_runtime!(
     pub enum TestRuntime where
@@ -59,6 +60,7 @@ impl Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
+    type BatchBound = MockNftBatchBound;
 }
 
 parameter_types! {
@@ -155,12 +157,4 @@ impl TestAccount {
 
 pub fn sign(signer: &sr25519::Pair, message_to_sign: &[u8]) -> Signature {
     return Signature::from(signer.sign(message_to_sign))
-}
-
-pub fn nft_is_owned(owner: &AccountId, nft_id: &NftId) -> bool {
-    if <OwnedNfts<TestRuntime>>::contains_key(&owner) {
-        return NftManager::get_owned_nfts(owner).iter().any(|nft| nft == nft_id)
-    }
-
-    return false
 }

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -81,12 +81,21 @@ mod open_for_sale {
         pub fn inject_nft_to_chain(&self) -> (Nft<AccountId>, NftInfo<AccountId>) {
             return NftManager::insert_single_nft_into_chain(
                 self.info_id,
-                self.royalties.clone(),
+                self.bounded_royalties(),
                 self.t1_authority,
                 self.nft_id(),
-                self.unique_external_ref.clone(),
+                self.bounded_external_ref(),
                 self.nft_owner,
             )
+        }
+
+        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
+            BoundedVec::try_from(self.unique_external_ref.clone())
+                .expect("Unique external reference bound was exceeded.")
+        }
+
+        pub fn bounded_royalties(&self) -> BoundedVec<Royalty, NftRoyaltiesBound> {
+            BoundedVec::try_from(self.royalties.clone()).expect("Royalty bound was exceeded.")
         }
     }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
@@ -66,7 +66,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
@@ -68,7 +68,8 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Test string should not exceed bound"),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);

--- a/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
@@ -74,11 +74,11 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            String::from("Offchain location of NFT").into_bytes(),
+            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+                .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );
         <NftManager as Store>::Nfts::insert(self.nft_id, &nft);
-        <NftManager as Store>::OwnedNfts::insert(self.nft_owner_account, vec![self.nft_id]);
         <NftManager as Store>::NftOpenForSale::insert(&self.nft_id, NftSaleType::Fiat);
     }
 
@@ -152,34 +152,6 @@ mod proxy_signed_transfer_fiat_nft {
                 assert_ok!(NftManager::proxy(Origin::signed(context.relayer), call));
 
                 assert_eq!(false, <NftOpenForSale<TestRuntime>>::contains_key(&context.nft_id));
-            });
-        }
-
-        #[test]
-        fn nft_ownership_is_updated() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context = Context::default();
-                context.setup();
-                let call = context.create_signed_transfer_fiat_nft_call();
-
-                assert_eq!(
-                    context.nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(false, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
-
-                assert_ok!(NftManager::proxy(Origin::signed(context.relayer), call));
-
-                assert_eq!(
-                    context.new_nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(false, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(true, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
             });
         }
 
@@ -503,39 +475,6 @@ mod signed_transfer_fiat_nft {
                 ));
 
                 assert_eq!(false, <NftOpenForSale<TestRuntime>>::contains_key(&context.nft_id));
-            });
-        }
-
-        #[test]
-        fn nft_ownership_is_updated() {
-            let mut ext = ExtBuilder::build_default().as_externality();
-            ext.execute_with(|| {
-                let context = Context::default();
-                context.setup();
-                let proof = context.create_signed_transfer_fiat_nft_proof();
-
-                assert_eq!(
-                    context.nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(true, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(false, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
-
-                assert_ok!(NftManager::signed_transfer_fiat_nft(
-                    Origin::signed(context.nft_owner_account),
-                    proof,
-                    context.nft_id,
-                    context.t2_transfer_to_public_key
-                ));
-
-                assert_eq!(
-                    context.new_nft_owner_account,
-                    <Nfts<TestRuntime>>::get(&context.nft_id).unwrap().owner
-                );
-
-                assert_eq!(false, nft_is_owned(&context.nft_owner_account, &context.nft_id));
-                assert_eq!(true, nft_is_owned(&context.new_nft_owner_account, &context.nft_id));
             });
         }
 

--- a/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/single_mint_nft_tests.rs
@@ -100,7 +100,6 @@ mod mint_single_nft {
 
                 assert_eq!(true, <Nfts<TestRuntime>>::contains_key(&nft_id));
                 assert_eq!(true, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
-                assert_eq!(true, nft_is_owned(&context.owner, &context.generate_nft_id()));
                 assert_eq!(true, context.event_emitted_with_single_nft_minted());
             });
         }
@@ -164,6 +163,28 @@ mod mint_single_nft {
                 assert_noop!(
                     context.call_mint_single_nft(),
                     Error::<TestRuntime>::ExternalRefIsMandatory
+                );
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+            });
+        }
+
+        #[test]
+        fn external_ref_is_out_of_bounds() {
+            let mut ext = ExtBuilder::build_default().as_externality();
+            ext.execute_with(|| {
+                let mut context: Context = Default::default();
+                let expected_info_id: NftInfoId = NftManager::next_info_id();
+
+                assert_eq!(false, <Nfts<TestRuntime>>::contains_key(&context.generate_nft_id()));
+                assert_eq!(false, <NftInfos<TestRuntime>>::contains_key(&expected_info_id));
+                assert_eq!(false, context.event_emitted_with_single_nft_minted());
+
+                let out_of_bounds_size: u32 = <NftExternalRefBound as sp_core::Get<u32>>::get() + 1;
+                context.unique_external_ref = vec![b'A'; out_of_bounds_size as usize];
+
+                assert_noop!(
+                    context.call_mint_single_nft(),
+                    Error::<TestRuntime>::ExternalRefOutOfBounds
                 );
                 assert_eq!(false, context.event_emitted_with_single_nft_minted());
             });

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -10,7 +10,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.101", optional = true }
 rand = { version = "0.7.2", default-features = false }
 # Substrate
@@ -53,6 +53,8 @@ std = [
 	"pallet-authorship/std",
 	"pallet-avn/std",
 	"pallet-session/std",
+	"log/std",
+
 ]
 runtime-benchmarks = [ "frame-benchmarking" ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -7,10 +7,11 @@ use alloc::string::{String, ToString};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::{
+    bounds::VotingSessionIdBound,
     calculate_two_third_quorum,
     event_types::Validator,
     offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
-    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter, VotingSessionIdBound,
+    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter,
 };
 use sp_runtime::{
     scale_info::TypeInfo,

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -1721,7 +1721,7 @@ mod if_process_summary_is_called_a_second_time {
 mod constrains {
     use crate::{RootId, RootRange};
     use node_primitives::BlockNumber;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::Get;
 
     #[test]

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -44,8 +44,11 @@ use pallet_ethereum_transactions::{
 };
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
-    calculate_two_third_quorum, eth_key_actions::decompress_eth_public_key, event_types::Validator,
-    safe_add_block_numbers, IngressCounter, MaximumValidatorsBound, VotingSessionIdBound,
+    bounds::{MaximumValidatorsBound, VotingSessionIdBound},
+    calculate_two_third_quorum,
+    eth_key_actions::decompress_eth_public_key,
+    event_types::Validator,
+    safe_add_block_numbers, IngressCounter,
 };
 use sp_core::{bounded::BoundedVec, ecdsa, H512};
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -618,7 +618,7 @@ mod add_validator {
 mod constrains {
 
     use crate::ActionId;
-    use sp_avn_common::VotingSessionIdBound;
+    use sp_avn_common::bounds::VotingSessionIdBound;
     use sp_core::{sr25519::Public, Get};
 
     #[test]

--- a/primitives/avn-common/Cargo.toml
+++ b/primitives/avn-common/Cargo.toml
@@ -26,7 +26,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-log = { version = "0.4.8", optional = true, features = ["std"] }
+log = { version = "0.4.17", default-features = false }
 
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
 sha3 = { version = "0.8", default-features = false }
@@ -36,7 +36,6 @@ byte-slice-cast = "1.2.1"
 sha3 = {version = "0.8.2", default-features = false }
 
 [features]
-default = [ "std" ]
 std = [
 	"serde",
 	"codec/std",
@@ -44,7 +43,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"log",
+	"log/std",
 	"libsecp256k1/std",
 	"sha3/std"
 ]

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use codec::{Codec, Decode, Encode};
-use sp_core::{crypto::KeyTypeId, ecdsa, ConstU32, H160};
+use sp_core::{crypto::KeyTypeId, ecdsa, H160};
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::keccak_256, EcdsaVerifyError};
 use sp_runtime::{
     scale_info::TypeInfo,
@@ -38,10 +38,17 @@ pub const ETHEREUM_PREFIX: &'static [u8] = b"\x19Ethereum Signed Message:\n32";
 pub const EXTERNAL_SERVICE_PORT_NUMBER_KEY: &'static [u8; 15] = b"avn_port_number";
 /// Default port number the external service runs on.
 pub const DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER: &str = "2020";
-/// Bound used for Vectors containing validators
-pub type MaximumValidatorsBound = ConstU32<256>;
-/// Bound used for voting session IDs
-pub type VotingSessionIdBound = ConstU32<64>;
+
+pub mod bounds {
+    use sp_core::ConstU32;
+
+    /// Bound used for Vectors containing validators
+    pub type MaximumValidatorsBound = ConstU32<256>;
+    /// Bound used for voting session IDs
+    pub type VotingSessionIdBound = ConstU32<64>;
+    /// Bound used for NFT external references
+    pub type NftExternalRefBound = ConstU32<1024>;
+}
 
 #[derive(Debug)]
 pub enum ECDSAVerificationError {

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -639,7 +639,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
-    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
+    type BatchBound = pallet_nft_manager::BatchNftBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 36,
+    spec_version: 37,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -639,6 +639,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
+    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -658,7 +658,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
-    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
+    type BatchBound = pallet_nft_manager::BatchNftBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 36,
+    spec_version: 37,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -658,6 +658,7 @@ impl pallet_nft_manager::Config for Runtime {
     type ProcessedEventsChecker = EthereumEvents;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
+    type BatchBound = sp_avn_common::bounds::NftExternalRefBound;
     type WeightInfo = pallet_nft_manager::default_weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
## Proposed changes
Reintroduces 3c08ed8 commit but with the correct BatchNft bounds.
[Diff changes with 3.1.0 release](https://github.com/Aventus-Network-Services/avn-parachain/compare/v3.1.0...bb546d1d033c1a5a97f93209a19e8c90d6406a10)

Converts the nft manager storage items to bounded.
This includes:
- batch size
- external references
- royalties

Added migration truncating and updating data that exceeded the boundaries
Updated tests and benchmarks
Updated log library std dependencies

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
