### PR TITLE
SYS-3555 convert parachain staking to bounded vec storage items (#198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-finality-tracker"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-transactions"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7495,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "3.2.1"
+version = "3.2.2"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -34,10 +34,12 @@ use pallet_authorship::EventHandler;
 use parity_scale_codec::{Decode, Encode};
 use rand::{RngCore, SeedableRng};
 use sp_application_crypto::KeyTypeId;
+use sp_core::{bounded::BoundedVec, ConstU32};
 use sp_runtime::{traits::StaticLookup, RuntimeAppPublic};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 pub const BENCH_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"test");
+pub type MaxNominations = ConstU32<100>;
 mod app_sr25519 {
     use super::BENCH_KEY_TYPE_ID;
     use sp_application_crypto::{app_crypto, sr25519};
@@ -1392,12 +1394,12 @@ benchmarks! {
             total_staking_reward: total_staked,
         });
 
-        let mut nominations: Vec<Bond<T::AccountId, BalanceOf<T>>> = Vec::new();
+        let mut nominations: BoundedVec<Bond<T::AccountId, BalanceOf<T>>, MaxNominations> = BoundedVec::default();
         for nominator in &nominators {
-            nominations.push(Bond {
+            nominations.try_push(Bond {
                 owner: nominator.clone(),
                 amount: 100u32.into(),
-            });
+            }).unwrap();
         }
 
         <AtStake<T>>::insert(era_for_payout, &sole_collator, CollatorSnapshot {

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -15,11 +15,12 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 /* TODO: use orml_utilities::OrderedSet without leaking substrate v2.0 dependencies */
-use parity_scale_codec::{Decode, Encode};
+use frame_support::traits::Get;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{BoundedVec, RuntimeDebug};
 use sp_std::prelude::*;
 
 /// An ordered set backed by `Vec`
@@ -84,6 +85,75 @@ impl<T: Ord> OrderedSet<T> {
 
 impl<T: Ord> From<Vec<T>> for OrderedSet<T> {
     fn from(v: Vec<T>) -> Self {
+        Self::from(v)
+    }
+}
+
+/// An ordered set backed by `BoundedVec`
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(RuntimeDebug, PartialEq, Eq, Encode, Decode, TypeInfo, Clone, MaxEncodedLen)]
+#[scale_info(skip_type_params(S))]
+pub struct BoundedOrderedSet<T, S: Get<u32>>(pub BoundedVec<T, S>);
+
+impl<T, S: Get<u32>> sp_std::default::Default for BoundedOrderedSet<T, S> {
+    fn default() -> Self {
+        BoundedOrderedSet(BoundedVec::default())
+    }
+}
+
+impl<T: Ord, S: Get<u32>> BoundedOrderedSet<T, S> {
+    /// Create a new empty set
+    pub fn new() -> Self {
+        Self(BoundedVec::default())
+    }
+
+    /// Create a set from a `Vec`.
+    /// `v` will be sorted and dedup first.
+    pub fn from(mut v: BoundedVec<T, S>) -> Self {
+        v.sort();
+        let v = v.try_mutate(|inner| inner.dedup()).expect(
+            "input is a valid BoundedVec and deduping can only reduce the number of entires; qed",
+        );
+        Self(v)
+    }
+
+    /// Insert an element.
+    /// Return true if insertion happened.
+    pub fn try_insert(&mut self, value: T) -> Result<bool, ()> {
+        match self.0.binary_search(&value) {
+            Ok(_) => Ok(false),
+            Err(loc) => self.0.try_insert(loc, value).map(|_| true).map_err(|_| ()),
+        }
+    }
+
+    /// Remove an element.
+    /// Return true if removal happened.
+    pub fn remove(&mut self, value: &T) -> bool {
+        match self.0.binary_search(value) {
+            Ok(loc) => {
+                self.0.remove(loc);
+                true
+            },
+            Err(_) => false,
+        }
+    }
+
+    /// Return if the set contains `value`
+    pub fn contains(&self, value: &T) -> bool {
+        self.0.binary_search(value).is_ok()
+    }
+
+    /// Clear the set
+    pub fn clear(mut self) {
+        let v = self.0.try_mutate(|inner| inner.clear()).expect(
+            "input is a valid BoundedVec and clearing can only reduce the number of entires; qed",
+        );
+        self.0 = v;
+    }
+}
+
+impl<T: Ord, S: Get<u32>> From<BoundedVec<T, S>> for BoundedOrderedSet<T, S> {
+    fn from(v: BoundedVec<T, S>) -> Self {
         Self::from(v)
     }
 }

--- a/pallets/parachain-staking/src/tests/bond_extra_tests.rs
+++ b/pallets/parachain-staking/src/tests/bond_extra_tests.rs
@@ -100,7 +100,7 @@ mod proxy_signed_bond_extra {
 
                 // The staker state has also been updated
                 let staker_state = ParachainStaking::nominator_state(staker.account_id).unwrap();
-                assert_eq!(staker_state.total(), initial_stake * 2 + amount_to_topup);
+                assert_eq!(staker_state.total, initial_stake * 2 + amount_to_topup);
 
                 // Each collator that has been nominated has been topped up by the expected amount
                 let nominations = staker_state.nominations.0.clone();
@@ -202,7 +202,7 @@ mod proxy_signed_bond_extra {
 
                 // The staker state has also been updated
                 let staker_state = ParachainStaking::nominator_state(staker.account_id).unwrap();
-                assert_eq!(staker_state.total(), initial_stake * 5 + amount_to_topup);
+                assert_eq!(staker_state.total, initial_stake * 5 + amount_to_topup);
 
                 // The staker free balance has been reduced
                 assert_eq!(
@@ -802,15 +802,9 @@ fn nominator_bond_extra_updates_nominator_state() {
         .with_nominations(vec![(account_id_2, account_id, 10)])
         .build()
         .execute_with(|| {
-            assert_eq!(
-                ParachainStaking::nominator_state(account_id_2).expect("exists").total(),
-                10
-            );
+            assert_eq!(ParachainStaking::nominator_state(account_id_2).expect("exists").total, 10);
             assert_ok!(ParachainStaking::bond_extra(Origin::signed(account_id_2), account_id, 5));
-            assert_eq!(
-                ParachainStaking::nominator_state(account_id_2).expect("exists").total(),
-                15
-            );
+            assert_eq!(ParachainStaking::nominator_state(account_id_2).expect("exists").total, 15);
         });
 }
 

--- a/pallets/parachain-staking/src/tests/mock.rs
+++ b/pallets/parachain-staking/src/tests/mock.rs
@@ -49,6 +49,7 @@ pub type AccountId = <Signature as Verify>::Signer;
 pub type Signature = sr25519::Signature;
 pub type Balance = u128;
 pub type BlockNumber = u64;
+pub type MaxNominations = u64;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -200,6 +201,7 @@ parameter_types! {
     pub const MinNominationPerCollator: u128 = 1;
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
+    pub const MaxCandidates:u32 = 100;
 }
 
 pub struct IsRegistered;
@@ -228,6 +230,7 @@ impl Config for Test {
     type CollatorSessionRegistration = IsRegistered;
     type CollatorPayoutDustHandler = TestCollatorPayoutDustHandler;
     type WeightInfo = ();
+    type MaxCandidates = MaxCandidates;
 }
 
 // Deal with any positive imbalance by sending it to the fake treasury

--- a/pallets/parachain-staking/src/tests/nominate_tests.rs
+++ b/pallets/parachain-staking/src/tests/nominate_tests.rs
@@ -104,7 +104,7 @@ mod proxy_signed_nominate {
 
                 // The staker state has also been updated
                 let staker_state = ParachainStaking::nominator_state(staker.account_id).unwrap();
-                assert_eq!(staker_state.total(), amount_to_stake);
+                assert_eq!(staker_state.total, amount_to_stake);
 
                 // Each collator has been nominated by the expected amount
                 for (index, collator) in collators.into_iter().enumerate() {
@@ -197,7 +197,7 @@ mod proxy_signed_nominate {
                 let staker_state = ParachainStaking::nominator_state(staker.account_id).unwrap();
 
                 // The staker state has also been updated
-                assert_eq!(staker_state.total(), amount_to_stake);
+                assert_eq!(staker_state.total, amount_to_stake);
 
                 // The staker free balance has been reduced
                 assert_eq!(
@@ -540,7 +540,7 @@ mod existing_direct_nominate_tests {
                 ));
                 let nominator_state = ParachainStaking::nominator_state(account_id_2)
                     .expect("just nominated => exists");
-                assert_eq!(nominator_state.total(), 10);
+                assert_eq!(nominator_state.total, 10);
                 assert_eq!(nominator_state.nominations.0[0].owner, account_id);
                 assert_eq!(nominator_state.nominations.0[0].amount, 10);
             });

--- a/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
+++ b/pallets/parachain-staking/src/tests/schedule_unbond_tests.rs
@@ -755,7 +755,7 @@ mod signed_execute_nomination_request {
                     ParachainStaking::get_nominator_stakable_free_balance(&staker.account_id);
                 let initial_total_stake = ParachainStaking::total();
                 let initial_state_total =
-                    ParachainStaking::nominator_state(staker.account_id).unwrap().total();
+                    ParachainStaking::nominator_state(staker.account_id).unwrap().total;
                 let initial_collator1_state =
                     &ParachainStaking::top_nominations(collator_1).unwrap().nominations[0];
                 let initial_collator2_state =
@@ -789,7 +789,7 @@ mod signed_execute_nomination_request {
                 );
                 assert_eq!(ParachainStaking::total(), initial_total_stake - amount_to_unbond);
                 assert_eq!(
-                    ParachainStaking::nominator_state(staker.account_id).unwrap().total(),
+                    ParachainStaking::nominator_state(staker.account_id).unwrap().total,
                     initial_state_total - amount_to_unbond
                 );
                 assert_eq!(
@@ -1669,10 +1669,7 @@ fn execute_nominator_unbond_updates_nominator_state() {
         .with_nominations(vec![(account_id_2, account_id, 10)])
         .build()
         .execute_with(|| {
-            assert_eq!(
-                ParachainStaking::nominator_state(account_id_2).expect("exists").total(),
-                10
-            );
+            assert_eq!(ParachainStaking::nominator_state(account_id_2).expect("exists").total, 10);
             assert_ok!(ParachainStaking::schedule_nominator_unbond(
                 RuntimeOrigin::signed(account_id_2),
                 account_id,
@@ -1684,7 +1681,7 @@ fn execute_nominator_unbond_updates_nominator_state() {
                 account_id_2,
                 account_id
             ));
-            assert_eq!(ParachainStaking::nominator_state(account_id_2).expect("exists").total(), 5);
+            assert_eq!(ParachainStaking::nominator_state(account_id_2).expect("exists").total, 5);
         });
 }
 

--- a/pallets/parachain-staking/src/tests/test_bounded_ordered_set.rs
+++ b/pallets/parachain-staking/src/tests/test_bounded_ordered_set.rs
@@ -1,0 +1,98 @@
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use frame_support::traits::Get;
+    use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+    use scale_info::TypeInfo;
+    use sp_core::RuntimeDebug;
+    use sp_runtime::BoundedVec;
+
+    use crate::set::BoundedOrderedSet;
+
+    #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+    pub struct MaxBound;
+
+    impl Get<u32> for MaxBound {
+        fn get() -> u32 {
+            const MAX_NOMINATIONS: u32 = 100;
+            MAX_NOMINATIONS
+        }
+    }
+
+    fn vec_to_ordered_set<T: Ord + Debug + Clone, S: Get<u32>>(
+        values: Vec<T>,
+    ) -> BoundedOrderedSet<T, S> {
+        let mut bounded_vec: BoundedVec<T, S> = BoundedVec::truncate_from(values);
+
+        let mut new_bounded_vec = BoundedVec::default(); // Create a new BoundedVec
+        for value in bounded_vec.iter() {
+            new_bounded_vec
+                .try_push(value.clone())
+                .expect("Failed to push value into new BoundedVec");
+        }
+
+        BoundedOrderedSet::from(new_bounded_vec)
+    }
+
+    #[test]
+    fn test_new() {
+        let set: BoundedOrderedSet<i32, MaxBound> = BoundedOrderedSet::new();
+        assert!(set.0.is_empty());
+    }
+
+    #[test]
+    fn test_from() {
+        let vec = vec![3, 1, 4, 1, 5, 9];
+        let set: BoundedOrderedSet<i32, MaxBound> = vec_to_ordered_set(vec);
+
+        assert_eq!(set.0.len(), 5);
+        assert_eq!(set.0[0], 1);
+        assert_eq!(set.0[1], 3);
+        assert_eq!(set.0[2], 4);
+        assert_eq!(set.0[3], 5);
+    }
+
+    #[test]
+    fn test_try_insert() {
+        let mut set: BoundedOrderedSet<u32, MaxBound> = BoundedOrderedSet::new();
+
+        assert_eq!(set.try_insert(3), Ok(true));
+        assert_eq!(set.try_insert(1), Ok(true));
+        assert_eq!(set.try_insert(4), Ok(true));
+        assert_eq!(set.try_insert(1), Ok(false));
+        assert_eq!(set.0.len(), 3);
+        assert_eq!(set.0[0], 1);
+        assert_eq!(set.0[1], 3);
+        assert_eq!(set.0[2], 4);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut set = vec_to_ordered_set::<i32, MaxBound>(vec![3, 1, 4]);
+
+        assert_eq!(set.remove(&3), true);
+        assert_eq!(set.remove(&2), false);
+
+        assert_eq!(set.0.len(), 2);
+        assert_eq!(set.0[0], 1);
+        assert_eq!(set.0[1], 4);
+    }
+
+    #[test]
+    fn test_contains() {
+        let set = vec_to_ordered_set::<i32, MaxBound>(vec![3, 1, 4]);
+
+        assert_eq!(set.contains(&3), true);
+        assert_eq!(set.contains(&2), false);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut set = vec_to_ordered_set::<i32, MaxBound>(vec![3, 1, 4]);
+
+        assert!(!set.0.is_empty()); // Assert before clearing
+        let set_clone = set.clone(); // Clone the set
+        set.clear();
+    }
+}

--- a/pallets/parachain-staking/src/tests/test_growth.rs
+++ b/pallets/parachain-staking/src/tests/test_growth.rs
@@ -407,6 +407,9 @@ mod growth_info_recorded_correctly {
 }
 
 mod growth_amount {
+    use sp_core::ConstU32;
+    use sp_runtime::BoundedVec;
+
     use super::*;
 
     const PERIOD_INDEX: u32 = 1;
@@ -415,12 +418,13 @@ mod growth_amount {
     const COLLATOR_BALANCE: u128 = 100;
     const COLLATOR1_POINTS: u32 = 20;
     const COLLATOR2_POINTS: u32 = 10;
+    // const CollatorMaxScores: ConstU32<10000> = 10000;
 
     fn set_growth_data(
         total_staked: u128,
         staking_reward: u128,
         total_points: u32,
-        collator_scores: Vec<CollatorScore<AccountId>>,
+        collator_scores: BoundedVec<CollatorScore<AccountId>, ConstU32<10000>>,
     ) {
         <GrowthPeriod<Test>>::put(GrowthPeriodInfo { start_era_index: 1, index: 1 });
 
@@ -457,10 +461,10 @@ mod growth_amount {
                         TOTAL_STAKE,
                         TOTAL_REWARD,
                         total_points,
-                        vec![
+                        BoundedVec::truncate_from(vec![
                             CollatorScore::new(collator_1, COLLATOR1_POINTS),
                             CollatorScore::new(previous_collator_3, previous_collator3_points),
-                        ],
+                        ]),
                     );
 
                     // Initial state
@@ -637,10 +641,10 @@ mod growth_amount {
                         TOTAL_STAKE,
                         TOTAL_REWARD,
                         total_points,
-                        vec![
+                        BoundedVec::truncate_from(vec![
                             CollatorScore::new(collator_1, COLLATOR1_POINTS),
                             CollatorScore::new(collator_2, COLLATOR2_POINTS),
-                        ],
+                        ]),
                     );
 
                     assert_eq!(true, <Growth<Test>>::contains_key(PERIOD_INDEX));
@@ -672,10 +676,10 @@ mod growth_amount {
                         TOTAL_STAKE,
                         TOTAL_REWARD,
                         total_points,
-                        vec![
+                        BoundedVec::truncate_from(vec![
                             CollatorScore::new(collator_1, COLLATOR1_POINTS),
                             CollatorScore::new(collator_2, COLLATOR2_POINTS),
-                        ],
+                        ]),
                     );
 
                     assert_eq!(true, <Growth<Test>>::contains_key(PERIOD_INDEX));

--- a/pallets/token-manager/src/mock.rs
+++ b/pallets/token-manager/src/mock.rs
@@ -214,6 +214,7 @@ parameter_types! {
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPaymentDelay: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
+    pub const MaxCandidates: u32 = 100;
 }
 
 impl parachain_staking::Config for TestRuntime {
@@ -235,6 +236,7 @@ impl parachain_staking::Config for TestRuntime {
     type CollatorPayoutDustHandler = TokenManager;
     type ProcessedEventsChecker = ();
     type WeightInfo = ();
+    type MaxCandidates = MaxCandidates;
 }
 
 impl WeightToFeeT for WeightToFee {

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -405,6 +405,7 @@ parameter_types! {
     pub const ErasPerGrowthPeriod: u32 = 2;
     pub const RewardPaymentDelay: u32 = 2;
     pub const RewardPotId: PalletId = PalletId(*b"av/vamgr");
+    pub const MaxCandidates: u32 = 256;
 }
 
 impl parachain_staking::Config for TestRuntime {
@@ -426,6 +427,7 @@ impl parachain_staking::Config for TestRuntime {
     type CollatorPayoutDustHandler = ();
     type ProcessedEventsChecker = ();
     type WeightInfo = ();
+    type MaxCandidates = MaxCandidates;
 }
 
 /// A mock offence report handler.

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 37,
+    spec_version: 38,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -465,6 +465,7 @@ impl pallet_parachain_staking::Config for Runtime {
     type CollatorSessionRegistration = Session;
     type CollatorPayoutDustHandler = TokenManager;
     type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
+    type MaxCandidates = ConstU32<100>;
 }
 
 // Substrate pallets that AvN has dependency

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 37,
+    spec_version: 38,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -483,6 +483,7 @@ impl pallet_parachain_staking::Config for Runtime {
     type CollatorSessionRegistration = Session;
     type CollatorPayoutDustHandler = TokenManager;
     type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
+    type MaxCandidates = ConstU32<100>;
 }
 
 // Substrate pallets that AvN has dependency


### PR DESCRIPTION
## Proposed changes
Reinstates commit 74ed078 and the work done on #198 
this PR introduces bounded data structures to parachain-staking
Related Jira items:
- SYS-3338
## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
