### PR TITLE
SYS-3338 Uses WeakBoundedVector for external reference

### DIFF
--- a/pallets/nft-manager/src/batch_nft.rs
+++ b/pallets/nft-manager/src/batch_nft.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use frame_support::{dispatch::DispatchError, ensure};
 use sp_avn_common::event_types::NftMintData;
-use sp_core::bounded::BoundedVec;
+use sp_core::bounded::{BoundedVec, WeakBoundedVec};
 
 pub const SIGNED_CREATE_BATCH_CONTEXT: &'static [u8] = b"authorization for create batch operation";
 pub const SIGNED_MINT_BATCH_NFT_CONTEXT: &'static [u8] =
@@ -161,7 +161,7 @@ pub fn process_mint_batch_nft_event<T: Config>(
 
 pub fn validate_mint_batch_nft_request<T: Config>(
     batch_id: NftBatchId,
-    unique_external_ref: &BoundedVec<u8, NftExternalRefBound>,
+    unique_external_ref: &WeakBoundedVec<u8, NftExternalRefBound>,
 ) -> Result<NftInfo<T::AccountId>, DispatchError> {
     ensure!(batch_id.is_zero() == false, Error::<T>::BatchIdIsMandatory);
     ensure!(<BatchInfoId<T>>::contains_key(&batch_id), Error::<T>::BatchDoesNotExist);
@@ -182,7 +182,7 @@ pub fn mint_batch_nft<T: Config>(
     batch_id: NftBatchId,
     owner: T::AccountId,
     sale_index: u64,
-    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+    unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
 ) -> DispatchResult {
     let nft_info = validate_mint_batch_nft_request::<T>(batch_id, &unique_external_ref)?;
     let nft_id = generate_batch_nft_id::<T>(&batch_id, &sale_index);

--- a/pallets/nft-manager/src/benchmarking.rs
+++ b/pallets/nft-manager/src/benchmarking.rs
@@ -66,8 +66,8 @@ fn get_proof<T: Config>(
     }
 }
 
-fn bounded_unique_external_ref() -> BoundedVec<u8, NftExternalRefBound> {
-    BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+fn bounded_unique_external_ref() -> WeakBoundedVec<u8, NftExternalRefBound> {
+    WeakBoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
         .expect("Unique external reference bound was exceeded.")
 }
 
@@ -94,7 +94,7 @@ struct MintSingleNft<T: Config> {
     nft_owner: T::AccountId,
     nft_id: U256,
     info_id: U256,
-    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+    unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
     royalties: Vec<Royalty>,
     t1_authority: H160,
     signature: Vec<u8>,
@@ -150,7 +150,7 @@ impl<T: Config> MintSingleNft<T> {
     fn setup(self) -> Self {
         <Nfts<T>>::remove(&self.nft_id);
         <NftInfos<T>>::remove(&self.nft_id);
-        <UsedExternalReferences<T>>::remove(&self.weak_bounded_external_ref());
+        <UsedExternalReferences<T>>::remove(&self.bounded_external_ref());
         return self
     }
 
@@ -166,7 +166,7 @@ impl<T: Config> MintSingleNft<T> {
         .into()
     }
 
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+    pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
         WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
             .expect("Unique external reference bound was exceeded.")
     }
@@ -436,7 +436,7 @@ struct MintBatchNft<T: Config> {
     nft_owner: T::AccountId,
     batch_id: NftBatchId,
     nft_id: U256,
-    unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+    unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
     t1_authority: H160,
     signature: Vec<u8>,
 }
@@ -486,7 +486,7 @@ impl<T: Config> MintBatchNft<T> {
         }
     }
 
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+    pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
         WeakBoundedVec::try_from(self.unique_external_ref.to_vec())
             .expect("Unique external reference bound was exceeded.")
     }
@@ -617,8 +617,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -652,8 +652,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
             owner: mint_nft.nft_owner,
@@ -775,8 +775,8 @@ benchmarks! {
             NftInfo::new(mint_nft.info_id, bounded_royalties(mint_nft.royalties.clone()), mint_nft.t1_authority),
             <NftInfos<T>>::get(&mint_nft.info_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&mint_nft.bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(mint_nft.bounded_external_ref()));
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: mint_nft.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::SingleNftMinted {
             nft_id: mint_nft.nft_id,
@@ -878,8 +878,8 @@ benchmarks! {
             Nft::new(context.nft_id, U256::zero(), context.unique_external_ref.clone(), context.nft_owner.clone()),
             Nfts::<T>::get(&context.nft_id).unwrap()
         );
-        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.weak_bounded_external_ref()));
-        assert_eq!(true, <UsedExternalReferences<T>>::get(context.weak_bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::contains_key(&context.bounded_external_ref()));
+        assert_eq!(true, <UsedExternalReferences<T>>::get(context.bounded_external_ref()));
 
         assert_last_event::<T>(Event::<T>::CallDispatched{ relayer: context.relayer.clone(), hash: call_hash }.into());
         assert_last_nth_event::<T>(Event::<T>::BatchNftMinted {

--- a/pallets/nft-manager/src/nft_data.rs
+++ b/pallets/nft-manager/src/nft_data.rs
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
-use sp_core::bounded::BoundedVec;
+use sp_core::bounded::{BoundedVec, WeakBoundedVec};
 use sp_runtime::traits::Member;
 
 pub(crate) use sp_avn_common::bounds::NftExternalRefBound;
@@ -48,7 +48,7 @@ pub struct Nft<AccountId: Member> {
     /// Id of an info struct instance
     pub info_id: NftInfoId,
     /// Unique reference to the NFT asset stored off-chain
-    pub unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+    pub unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
     /// Transfer nonce of this NFT
     pub nonce: u64,
     /// Owner account address of this NFT
@@ -63,7 +63,7 @@ impl<AccountId: Member> Nft<AccountId> {
     pub fn new(
         nft_id: NftId,
         info_id: NftInfoId,
-        unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+        unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
         owner: AccountId,
     ) -> Self {
         return Nft::<AccountId> {

--- a/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
+++ b/pallets/nft-manager/src/tests/cancel_single_nft_listing_tests.rs
@@ -96,8 +96,8 @@ mod cancel_single_nft_listing {
             return NftCancelListingData { nft_id: self.nft_id(), op_id: self.op_id }
         }
 
-        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
-            BoundedVec::try_from(self.unique_external_ref.clone())
+        pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+            WeakBoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
         }
 

--- a/pallets/nft-manager/src/tests/open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/open_for_sale_tests.rs
@@ -89,8 +89,8 @@ mod open_for_sale {
             )
         }
 
-        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
-            BoundedVec::try_from(self.unique_external_ref.clone())
+        pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+            WeakBoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
         }
 

--- a/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_cancel_list_fiat_nft_tests.rs
@@ -66,7 +66,7 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+            WeakBoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
                 .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );

--- a/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_list_nft_open_for_sale_tests.rs
@@ -68,7 +68,7 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+            WeakBoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
                 .expect("Test string should not exceed bound"),
             self.nft_owner_account,
         );

--- a/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_mint_single_nft_tests.rs
@@ -83,7 +83,7 @@ impl Context {
     fn setup(&self) {
         <Nfts<TestRuntime>>::remove(&self.nft_id);
         <NftInfos<TestRuntime>>::remove(&self.nft_id);
-        <UsedExternalReferences<TestRuntime>>::remove(&self.weak_bounded_external_ref());
+        <UsedExternalReferences<TestRuntime>>::remove(&self.bounded_external_ref());
     }
 
     fn create_signed_mint_single_nft_call(&self) -> Box<<TestRuntime as Config>::RuntimeCall> {
@@ -133,12 +133,7 @@ impl Context {
         })
     }
 
-    pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
-        BoundedVec::try_from(self.unique_external_ref.clone())
-            .expect("Unique external reference bound was exceeded.")
-    }
-
-    pub fn weak_bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+    pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
         WeakBoundedVec::try_from(self.unique_external_ref.clone())
             .expect("Unique external reference bound was exceeded.")
     }
@@ -216,7 +211,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -225,12 +220,12 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -320,7 +315,7 @@ mod proxy_signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.weak_bounded_external_ref(),
+                    &context.bounded_external_ref(),
                     true,
                 );
                 let call = context.create_signed_mint_single_nft_call();
@@ -442,7 +437,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -483,7 +478,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -524,7 +519,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -568,7 +563,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -614,7 +609,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -657,7 +652,7 @@ mod proxy_signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -744,7 +739,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
 
@@ -759,12 +754,12 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     true,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(
                     true,
-                    <UsedExternalReferences<TestRuntime>>::get(context.weak_bounded_external_ref())
+                    <UsedExternalReferences<TestRuntime>>::get(context.bounded_external_ref())
                 );
             });
         }
@@ -844,7 +839,7 @@ mod signed_mint_single_nft {
                 let context = Context::default();
                 context.setup();
                 <UsedExternalReferences<TestRuntime>>::insert(
-                    &context.weak_bounded_external_ref(),
+                    &context.bounded_external_ref(),
                     true,
                 );
                 let proof = context.create_signed_mint_single_nft_proof();
@@ -987,7 +982,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1026,7 +1021,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1065,7 +1060,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1107,7 +1102,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1151,7 +1146,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());
@@ -1192,7 +1187,7 @@ mod signed_mint_single_nft {
                 assert_eq!(
                     false,
                     <UsedExternalReferences<TestRuntime>>::contains_key(
-                        &context.weak_bounded_external_ref()
+                        &context.bounded_external_ref()
                     )
                 );
                 assert_eq!(false, context.mint_single_nft_event_emitted());

--- a/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
+++ b/pallets/nft-manager/src/tests/proxy_signed_transfer_fiat_nft_tests.rs
@@ -74,7 +74,7 @@ impl Context {
         let nft = Nft::new(
             self.nft_id,
             NftManager::get_info_id_and_advance(),
-            BoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
+            WeakBoundedVec::try_from(String::from("Offchain location of NFT").into_bytes())
                 .expect("Unique external reference bound was exceeded."),
             self.nft_owner_account,
         );

--- a/pallets/nft-manager/src/tests/transfer_to_tests.rs
+++ b/pallets/nft-manager/src/tests/transfer_to_tests.rs
@@ -118,8 +118,8 @@ mod transfer_eth_nft {
             return NftManager::transfer_eth_nft(&self.event_id, &self.transfer_to_nft_data())
         }
 
-        pub fn bounded_external_ref(&self) -> BoundedVec<u8, NftExternalRefBound> {
-            BoundedVec::try_from(self.unique_external_ref.clone())
+        pub fn bounded_external_ref(&self) -> WeakBoundedVec<u8, NftExternalRefBound> {
+            WeakBoundedVec::try_from(self.unique_external_ref.clone())
                 .expect("Unique external reference bound was exceeded.")
         }
 

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -3,7 +3,7 @@ use codec::{Decode, Encode};
 use hex_literal::hex;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_core::{bounded::BoundedVec, H160, H256, H512, U256};
+use sp_core::{bounded::WeakBoundedVec, H160, H256, H512, U256};
 use sp_runtime::{scale_info::TypeInfo, traits::Member, DispatchResult};
 use sp_std::{convert::TryInto, vec::Vec};
 
@@ -291,7 +291,7 @@ pub struct NftMintData {
     #[deprecated(note = "must only be used for backwards compatibility reasons")]
     pub t1_contract_issuer: H160,
     pub sale_index: u64,
-    pub unique_external_ref: BoundedVec<u8, NftExternalRefBound>,
+    pub unique_external_ref: WeakBoundedVec<u8, NftExternalRefBound>,
 }
 
 impl NftMintData {
@@ -347,7 +347,7 @@ impl NftMintData {
         // The actual unique ref is expected to be a UUID which is made up of 32bytes (WORD_LENGTH)
         // + 4 bytes for the dashes Example: b1dc0452-8b2f-78ec-7e80-167002d11678
         let ref_size = WORD_LENGTH + 4 * BYTE_LENGTH;
-        let unique_external_ref = BoundedVec::<u8, NftExternalRefBound>::try_from(
+        let unique_external_ref = WeakBoundedVec::<u8, NftExternalRefBound>::try_from(
             data[2 * WORD_LENGTH..2 * WORD_LENGTH + ref_size].to_vec(),
         )
         .map_err(|_| Error::NftMintedEventBadRefLength)?;


### PR DESCRIPTION
## Proposed changes

Removes the migration of data during the upgrade since for large numbers of NFTs the migration could hault the upgrade.
Unique external reference field will use WeakBoundedVector to ensure that storage can be decoded for operations.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
