### PR TITLE
Add Dockerfile for Ubuntu 22.04 (jammy) builds

### DIFF
--- a/Dockerfile.22_04
+++ b/Dockerfile.22_04
@@ -1,0 +1,50 @@
+FROM ubuntu:22.04
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG IMAGE_NAME
+
+# TODO once public, add io.aventus.image.source
+LABEL io.aventus.image.authors="devops@aventus.io" \
+	io.aventus.image.vendor="Aventus Network Services" \
+	io.aventus.image.title="${IMAGE_NAME}" \
+	io.aventus.image.description="AvN parachain" \
+	io.aventus.image.revision="${VCS_REF}" \
+	io.aventus.image.created="${BUILD_DATE}" \
+	io.aventus.image.documentation="https://github.com/Aventus-Network-Services/avn-node-parachain"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+# install tools and dependencies
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	libssl3 \
+	ca-certificates \
+	curl \
+	jq && \
+	# apt cleanup
+	apt-get autoremove -y && \
+	apt-get clean && \
+	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
+	# add user and link ~/.local/share/avn-node to /data
+	useradd -m -u 1000 -U -s /bin/sh -d /avn-node avn-node && \
+	mkdir -p /data /avn-node/.local/share && \
+	chown -R avn-node:avn-node /data && \
+	ln -s /data /avn-node/.local/share/avn-node && \
+	mkdir -p /specs
+
+# add avn-node binary to the docker image
+COPY target/release/avn-parachain-collator /usr/local/bin/
+COPY target/release/wbuild/avn-parachain-runtime/avn_parachain_runtime*.wasm /avn/wbuild/
+
+USER avn-node
+
+# check if executable works in this container
+RUN /usr/local/bin/avn-parachain-collator --version
+
+EXPOSE 30333 30334 9933 9944 9615
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/local/bin/avn-parachain-collator"]

--- a/README.md
+++ b/README.md
@@ -125,10 +125,17 @@ cargo test
 # Test the benchmark tests
 cargo test --features runtime-benchmarks
 ```
+AvN binaries are built on Ubuntu 20.04 (focal), which is a Long Term Support (LTS) version. Consequently, these binaries may rely on certain native libraries such as OpenSSL. While Debian bullseye-based operating systems should be compatible, we highly recommend using Ubuntu 20.04 for running a node binary.
 ## Building the docker image
+When building an image, make sure the binary is located under the target/release folder.
+If you are using the official releases or have built binaries locally using Ubuntu 20.04:
 ```sh
-# Builds the docker image with the build artefacts under target/release
 docker build . --tag avn-node-parachain:latest
+```
+
+If you have built binaries locally using Ubuntu 22.04:
+```sh
+docker build -f Dockerfile.22_04 . --tag avn-node-parachain:latest
 ```
 
 ## Logs


### PR DESCRIPTION
## Proposed changes

This commit introduces a Dockerfile tailored for building with Ubuntu 22.04, which is compatible with Debian 12 (bookworm) based OS due to its use of OpenSSL3. The Docker image generated includes the necessary dependencies.

Additionally, the README has been updated to provide clearer instructions on selecting the appropriate Dockerfile for different build scenarios.

<!---Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.-->

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
