### PR TITLE
SYS-3338 Removes references of without_storage_info

### DIFF
--- a/pallets/avn-finality-tracker/src/lib.rs
+++ b/pallets/avn-finality-tracker/src/lib.rs
@@ -82,8 +82,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
-    // #[pallet::without_storage_info]
-    // TODO review the above - look at replacing all unbounded vectors so we can use this feature
     pub struct Pallet<T>(_);
 
     #[pallet::event]

--- a/pallets/avn-offence-handler/src/lib.rs
+++ b/pallets/avn-offence-handler/src/lib.rs
@@ -51,7 +51,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     #[pallet::event]

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -81,7 +81,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     #[pallet::error]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -138,7 +138,6 @@ pub mod pallet {
     /// Pallet for parachain staking
     #[pallet::pallet]
     #[pallet::storage_version(crate::migration::STORAGE_VERSION)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(PhantomData<T>);
 
     pub type EraIndex = u32;

--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -142,7 +142,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub (super) trait Store)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     #[pallet::event]


### PR DESCRIPTION
## Proposed changes

Removes the attribute `without_storage_info` from converted pallets.
This ensures that future development of the pallet will respect the bounded data structures prerequisite or throw an error during compilation

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successful run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
