### PR TITLE
SYS-3665 Add new `AvtLowered` event

### DIFF
--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -177,6 +177,12 @@ pub mod pallet {
             amount: u128,
             t1_recipient: H160,
         },
+        AvtLowered {
+            sender: T::AccountId,
+            recipient: T::AccountId,
+            amount: u128,
+            t1_recipient: H160,
+        },
         AvtTransferredFromTreasury {
             recipient: T::AccountId,
             amount: BalanceOf<T>,
@@ -504,6 +510,13 @@ impl<T: Config> Pallet<T> {
             // Decreases the total issued AVT when this negative imbalance is dropped
             // so that total issued AVT becomes equal to total supply once again.
             drop(imbalance);
+
+            Self::deposit_event(Event::<T>::AvtLowered {
+                sender: from.clone(),
+                recipient: to.clone(),
+                amount,
+                t1_recipient,
+            });
         } else {
             let lower_amount = <T::TokenBalance as TryFrom<u128>>::try_from(amount)
                 .or_else(|_error| Err(Error::<T>::AmountOverflow))?;

--- a/pallets/token-manager/src/test_avt_tokens.rs
+++ b/pallets/token-manager/src/test_avt_tokens.rs
@@ -150,7 +150,7 @@ fn avn_test_lower_all_avt_token_succeed() {
         .as_externality();
 
     ext.execute_with(|| {
-        let (_, from_account_id, _to_account_id, t1_recipient) =
+        let (_, from_account_id, to_account_id, t1_recipient) =
             MockData::setup_lower_request_data();
         let from_account_balance_before = Balances::free_balance(from_account_id);
         let amount = from_account_balance_before;
@@ -168,6 +168,13 @@ fn avn_test_lower_all_avt_token_succeed() {
                 who: from_account_id,
                 amount
             })));
+        assert!(System::events().iter().any(|a| a.event ==
+            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::AvtLowered {
+                sender: from_account_id,
+                recipient: to_account_id,
+                amount,
+                t1_recipient
+            })));
     });
 }
 
@@ -179,7 +186,7 @@ fn avn_test_lower_some_avt_token_succeed() {
         .as_externality();
 
     ext.execute_with(|| {
-        let (_, from_account_id, _to_account_id, t1_recipient) =
+        let (_, from_account_id, to_account_id, t1_recipient) =
             MockData::setup_lower_request_data();
         let from_account_balance_before = Balances::free_balance(from_account_id);
         let amount = from_account_balance_before / 2;
@@ -196,6 +203,13 @@ fn avn_test_lower_some_avt_token_succeed() {
             RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
                 who: from_account_id,
                 amount
+            })));
+        assert!(System::events().iter().any(|a| a.event ==
+            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::AvtLowered {
+                sender: from_account_id,
+                recipient: to_account_id,
+                amount,
+                t1_recipient
             })));
     });
 }
@@ -235,7 +249,7 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
         .as_externality();
 
     ext.execute_with(|| {
-        let (_, from_account_id, _to_account_id, _) = MockData::setup_lower_request_data();
+        let (_, from_account_id, to_account_id, _) = MockData::setup_lower_request_data();
         let mut from_account_balance_before = Balances::free_balance(from_account_id);
         let mut amount = from_account_balance_before;
         let t1_recipient = H160(hex!("0000000000000000000000000000000000000001"));
@@ -252,6 +266,13 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
             RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
                 who: from_account_id,
                 amount
+            })));
+        assert!(System::events().iter().any(|a| a.event ==
+            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::AvtLowered {
+                sender: from_account_id,
+                recipient: to_account_id,
+                amount,
+                t1_recipient
             })));
 
         // Lift and lower AVT tokens again
@@ -271,6 +292,13 @@ fn avn_test_avt_token_total_lowered_amount_greater_than_balance_max_value_ok() {
             RuntimeEvent::Balances(pallet_balances::Event::<TestRuntime>::Withdraw {
                 who: from_account_id,
                 amount
+            })));
+        assert!(System::events().iter().any(|a| a.event ==
+            RuntimeEvent::TokenManager(crate::Event::<TestRuntime>::AvtLowered {
+                sender: from_account_id,
+                recipient: to_account_id,
+                amount,
+                t1_recipient
             })));
     });
 }


### PR DESCRIPTION
## Proposed changes

This PR adds a new `AvtLowered` event that can be used to identify lower transactions by the lowering DApp
## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [x] Documentation updated
- [x] Business logic tested successfully
- [x] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.
