### PR TITLE
SYS-3630 Refactor quorum checking and fix eth-bridge OCW logic

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -18,12 +18,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 
-use frame_support::{
-    dispatch::DispatchResult,
-    ensure,
-    log::*,
-    traits::{Get, OneSessionHandler},
-};
+use frame_support::{dispatch::DispatchResult, log::*, traits::OneSessionHandler};
 use frame_system::{ensure_root, pallet_prelude::OriginFor};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
@@ -256,6 +251,11 @@ impl<T: Config> Pallet<T> {
                 local_keys.binary_search(&validator.key).ok().map(|_| validator)
             })
             .nth(0)
+    }
+
+    pub fn quorum() -> u32 {
+        let total_num_of_validators = Self::validators().len() as u32;
+        total_num_of_validators - total_num_of_validators * 2 / 3
     }
 
     pub fn get_data_from_service(url_path: String) -> Result<Vec<u8>, DispatchError> {

--- a/pallets/eth-bridge/src/util.rs
+++ b/pallets/eth-bridge/src/util.rs
@@ -1,20 +1,18 @@
 use super::*;
 use crate::{Config, AVN};
 use frame_support::{traits::UnixTime, BoundedVec};
-use sp_avn_common::calculate_one_third_quorum;
 
 pub fn time_now<T: Config>() -> u64 {
     <T as pallet::Config>::TimeProvider::now().as_secs()
 }
 
-pub fn quorum_reached<T: Config>(entries: u32) -> bool {
-    let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
-    entries >= quorum
+pub fn has_enough_corroborations<T: Config>(corroborations: usize) -> bool {
+    corroborations as u32 >= AVN::<T>::quorum()
 }
 
 pub fn has_enough_confirmations<T: Config>(active_tx: &ActiveTransactionData<T>) -> bool {
-    let num_confirmations_with_sender = active_tx.confirmations.len() as u32 + 1;
-    quorum_reached::<T>(num_confirmations_with_sender)
+    let num_confirmations_including_sender = active_tx.confirmations.len() as u32 + 1;
+    num_confirmations_including_sender >= AVN::<T>::quorum()
 }
 
 pub fn requires_corroboration<T: Config>(

--- a/pallets/ethereum-transactions/src/lib.rs
+++ b/pallets/ethereum-transactions/src/lib.rs
@@ -29,7 +29,6 @@ use sp_std::prelude::*;
 use pallet_avn::AvnBridgeContractAddress;
 
 use sp_avn_common::{
-    calculate_one_third_quorum,
     event_types::Validator,
     offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
     EthTransaction,
@@ -630,10 +629,7 @@ impl<T: Config> CandidateTransactionSubmitter<T::AccountId> for Pallet<T> {
 
         // Ensure the signatures count satisfy quorum before accepting
         let quorum = signatures.len() as u32;
-        ensure!(
-            quorum >= calculate_one_third_quorum(AVN::<T>::validators().len() as u32),
-            Error::<T>::NotEnoughConfirmations
-        );
+        ensure!(quorum >= AVN::<T>::quorum(), Error::<T>::NotEnoughConfirmations);
 
         // The following check is to ensure that we will not overwrite a value in the map,
         // this should never occur unless get_unique_transaction_identifier has a bug

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -520,7 +520,7 @@ fn generate_signature<T: pallet_avn::Config>(
 fn setup_voting_session<T: Config>(growth_id: &GrowthId) -> u32 {
     PendingApproval::<T>::insert(growth_id.period, growth_id.ingress_counter);
 
-    let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+    let quorum = AVN::<T>::quorum();
     let voting_period_end =
         safe_add_block_numbers(<system::Pallet<T>>::block_number(), VotingPeriod::<T>::get());
     let current_block_number: T::BlockNumber = 0u32.into();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -173,7 +173,6 @@ pub mod pallet {
     use sp_application_crypto::RuntimeAppPublic;
     pub use sp_avn_common::{
         bounds::VotingSessionIdBound,
-        calculate_one_third_quorum,
         event_types::Validator,
         offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
         safe_add_block_numbers, verify_signature, IngressCounter, Proof,
@@ -2698,7 +2697,7 @@ pub mod pallet {
                 AVN::<T>::calculate_primary_validator(<frame_system::Pallet<T>>::block_number())
                     .map_err(|_| Error::<T>::ErrorCalculatingPrimaryValidator)?;
 
-            let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+            let quorum = AVN::<T>::quorum();
             let ingress_counter = Self::get_ingress_counter();
             let current_block_number = <frame_system::Pallet<T>>::block_number();
             let voting_period_end =

--- a/pallets/summary/src/benchmarking.rs
+++ b/pallets/summary/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn setup_publish_root_voting<T: Config>(
 fn setup_voting_session<T: Config>(root_id: &RootId<T::BlockNumber>) -> u32 {
     PendingApproval::<T>::insert(root_id.range.clone(), root_id.ingress_counter);
 
-    let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+    let quorum = AVN::<T>::quorum();
     let voting_period_end =
         safe_add_block_numbers(<system::Pallet<T>>::block_number(), VotingPeriod::<T>::get());
     let current_block_number: T::BlockNumber = 0u32.into();

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -8,7 +8,6 @@ use alloc::string::{String, ToString};
 use codec::{Decode, Encode, MaxEncodedLen};
 use sp_avn_common::{
     bounds::VotingSessionIdBound,
-    calculate_one_third_quorum,
     event_types::Validator,
     offchain_worker_storage_lock::{self as OcwLock, OcwOperationExpiration},
     safe_add_block_numbers, safe_sub_block_numbers, IngressCounter,
@@ -424,7 +423,7 @@ pub mod pallet {
             );
             ensure!(new_block_number == expected_target_block, Error::<T>::InvalidSummaryRange);
 
-            let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+            let quorum = AVN::<T>::quorum();
             let voting_period_end =
                 safe_add_block_numbers(current_block_number, Self::voting_period())
                     .map_err(|_| Error::<T>::Overflow)?;

--- a/pallets/validators-manager/src/benchmarking.rs
+++ b/pallets/validators-manager/src/benchmarking.rs
@@ -170,7 +170,7 @@ fn setup_resignation_action_data<T: Config>(sender: T::AccountId, ingress_counte
 fn setup_voting_session<T: Config>(action_id: &ActionId<T::AccountId>) -> u32 {
     PendingApprovals::<T>::insert(action_id.action_account_id.clone(), action_id.ingress_counter);
 
-    let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+    let quorum = AVN::<T>::quorum();
     let voting_period_end =
         safe_add_block_numbers(<system::Pallet<T>>::block_number(), T::VotingPeriod::get());
     VotesRepository::<T>::insert(

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -45,7 +45,6 @@ use pallet_ethereum_transactions::{
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
     bounds::{MaximumValidatorsBound, VotingSessionIdBound},
-    calculate_one_third_quorum,
     eth_key_actions::decompress_eth_public_key,
     event_types::Validator,
     safe_add_block_numbers, IngressCounter,
@@ -1084,7 +1083,7 @@ impl<T: Config> NewSessionHandler<T::AuthorityId, T::AccountId> for Pallet<T> {
     ) {
         log::trace!("Validators manager on_new_session");
         if <ValidatorActions<T>>::iter().count() > 0 {
-            let quorum = calculate_one_third_quorum(AVN::<T>::validators().len() as u32);
+            let quorum = AVN::<T>::quorum();
             let voting_period_end =
                 safe_add_block_numbers(<system::Pallet<T>>::block_number(), T::VotingPeriod::get());
 
@@ -1121,7 +1120,7 @@ impl<T: Config> NewSessionHandler<T::AuthorityId, T::AccountId> for Pallet<T> {
                     Self::setup_voting_to_activate_validator(
                         ingress_counter,
                         &action_account_id,
-                        calculate_one_third_quorum(active_validators.len() as u32),
+                        AVN::<T>::quorum(),
                         voting_period_end,
                     );
                 }

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -123,10 +123,6 @@ pub fn safe_sub_block_numbers<BlockNumber: Member + Codec + AtLeast32Bit>(
     Ok(left.checked_sub(&right).ok_or(())?.into())
 }
 
-pub fn calculate_one_third_quorum(total_num_of_validators: u32) -> u32 {
-    return total_num_of_validators - total_num_of_validators * 2 / 3
-}
-
 pub fn recover_public_key_from_ecdsa_signature(
     signature: ecdsa::Signature,
     message: String,


### PR DESCRIPTION
OCW transaction processing logic was missing the condition to prevent sending whilst a tx still required confirmations. This is now added.

Additionally quorum getter has been refactored for clarity.