### PR TITLE
SYS-3634 Fixes to: handler name, view response decoding, extrinsic payload signing, avn invoke method

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -16,7 +16,10 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::string::{String, ToString};
+use alloc::{
+    format,
+    string::{String, ToString},
+};
 
 use frame_support::{dispatch::DispatchResult, log::*, traits::OneSessionHandler};
 use frame_system::{ensure_root, pallet_prelude::OriginFor};
@@ -403,7 +406,7 @@ impl<T: Config> Pallet<T> {
             Self::get_external_service_port_number(),
             url_path.trim_start_matches('/')
         );
-    
+
         let response = request
             .deadline(deadline)
             .url(&url)
@@ -421,14 +424,14 @@ impl<T: Config> Pallet<T> {
                 error!("❌ Invalid response: {:?}", e);
                 Error::<T>::InvalidResponse
             })?;
-    
+
         if response.code != 200 {
             error!("❌ Unexpected status code: {}", response.code);
-            return Err(Error::<T>::UnexpectedStatusCode.into());
+            return Err(Error::<T>::UnexpectedStatusCode)?
         }
-    
+
         Ok(response.body().collect())
-    }    
+    }
 }
 
 // Session pallet interface

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -402,7 +402,9 @@ impl<T: Config> Pallet<T> {
 
         let mut url = String::from("http://127.0.0.1:");
         url.push_str(&external_service_port_number);
-        url.push_str(&"/".to_string());
+        if !url_path.starts_with('/') {
+            url.push_str("/");
+        }
         url.push_str(&url_path);
 
         let pending = request
@@ -599,7 +601,7 @@ pub trait BridgePublisher {
     fn publish(function_name: &[u8], params: &[(Vec<u8>, Vec<u8>)]) -> Result<u32, DispatchError>;
 }
 
-pub trait OnPublishingResultHandler {
+pub trait OnBridgePublisherResult {
     fn process_result(tx_id: u32, succeeded: bool) -> DispatchResult;
 }
 

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -400,6 +400,7 @@ impl<T: Config> Pallet<T> {
         request: http::Request<Vec<Vec<u8>>>,
         url_path: String,
     ) -> Result<Vec<u8>, DispatchError> {
+        // TODO: Make this configurable
         let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(300_000));
         let url = format!(
             "http://127.0.0.1:{}/{}",

--- a/pallets/eth-bridge/src/call.rs
+++ b/pallets/eth-bridge/src/call.rs
@@ -3,21 +3,21 @@ use crate::{Author, Config};
 use sp_core::{ecdsa, H256};
 
 pub fn add_confirmation<T: Config>(tx_id: u32, confirmation: ecdsa::Signature, author: Author<T>) {
-    let proof = add_confirmation_proof::<T>(tx_id, &confirmation, &author);
+    let proof = add_confirmation_proof::<T>(tx_id, &confirmation, &author.account_id);
     let signature = author.key.sign(&proof).expect("Error signing proof");
     let call = Call::<T>::add_confirmation { tx_id, confirmation, author, signature };
     let _ = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into());
 }
 
 pub fn add_eth_tx_hash<T: Config>(tx_id: u32, eth_tx_hash: H256, author: Author<T>) {
-    let proof = add_eth_tx_hash_proof::<T>(tx_id, &eth_tx_hash, &author);
+    let proof = add_eth_tx_hash_proof::<T>(tx_id, &eth_tx_hash, &author.account_id);
     let signature = author.key.sign(&proof).expect("Error signing proof");
     let call = Call::<T>::add_eth_tx_hash { tx_id, eth_tx_hash, author, signature };
     let _ = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into());
 }
 
 pub fn add_corroboration<T: Config>(tx_id: u32, tx_succeeded: bool, author: Author<T>) {
-    let proof = add_corroboration_proof::<T>(tx_id, tx_succeeded, &author);
+    let proof = add_corroboration_proof::<T>(tx_id, tx_succeeded, &author.account_id);
     let signature = author.key.sign(&proof).expect("Error signing proof");
     let call = Call::<T>::add_corroboration { tx_id, tx_succeeded, author, signature };
     let _ = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into());
@@ -26,19 +26,23 @@ pub fn add_corroboration<T: Config>(tx_id: u32, tx_succeeded: bool, author: Auth
 fn add_confirmation_proof<T: Config>(
     tx_id: u32,
     confirmation: &ecdsa::Signature,
-    author: &Author<T>,
+    account_id: &T::AccountId,
 ) -> Vec<u8> {
-    (ADD_CONFIRMATION_CONTEXT, tx_id, confirmation, &author.account_id).encode()
+    (ADD_CONFIRMATION_CONTEXT, tx_id, confirmation, &account_id).encode()
 }
 
-fn add_eth_tx_hash_proof<T: Config>(tx_id: u32, eth_tx_hash: &H256, author: &Author<T>) -> Vec<u8> {
-    (ADD_ETH_TX_HASH_CONTEXT, tx_id, *eth_tx_hash, &author.account_id).encode()
+fn add_eth_tx_hash_proof<T: Config>(
+    tx_id: u32,
+    eth_tx_hash: &H256,
+    account_id: &T::AccountId,
+) -> Vec<u8> {
+    (ADD_ETH_TX_HASH_CONTEXT, tx_id, *eth_tx_hash, &account_id).encode()
 }
 
 fn add_corroboration_proof<T: Config>(
     tx_id: u32,
     tx_succeeded: bool,
-    author: &Author<T>,
+    account_id: &T::AccountId,
 ) -> Vec<u8> {
-    (ADD_CORROBORATION_CONTEXT, tx_id, tx_succeeded, &author.account_id).encode()
+    (ADD_CORROBORATION_CONTEXT, tx_id, tx_succeeded, &account_id).encode()
 }

--- a/pallets/eth-bridge/src/eth.rs
+++ b/pallets/eth-bridge/src/eth.rs
@@ -237,15 +237,15 @@ fn process_send_response<T: Config>(result: Vec<u8>) -> Result<H256, DispatchErr
 }
 
 fn process_view_response<T: Config>(result: Vec<u8>) -> Result<i8, DispatchError> {
-    if result.len() != 32 {
-        return Err(Error::<T>::InvalidViewResponseLength.into());
+    let result_bytes = hex::decode(&result).map_err(|_| Error::<T>::InvalidViewResponseData)?;
+
+    if result_bytes.len() != 32 {
+        return Err(Error::<T>::InvalidViewResponseLength.into())
     }
 
-    for &byte in &result[0..31] {
-        if byte != 0 && byte != 0xFF {
-            return Err(Error::<T>::InvalidViewResponseValue.into());
-        }
+    if !result_bytes[..31].iter().all(|&byte| byte == 0 || byte == 0xFF) {
+        return Err(Error::<T>::InvalidViewResponseValue.into())
     }
 
-    Ok(result[31] as i8)
+    Ok(result_bytes[31] as i8)
 }

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -233,6 +233,7 @@ pub mod pallet {
         InvalidHexString,
         InvalidUint,
         InvalidUTF8,
+        InvalidViewResponseData,
         InvalidViewResponseLength,
         InvalidViewResponseValue,
         MsgHashError,

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -50,7 +50,7 @@ impl Config for TestRuntime {
     type RuntimeCall = RuntimeCall;
     type WeightInfo = ();
     type AccountToBytesConvert = U64To32BytesConverter;
-    type OnPublishingResultHandler = TestRuntime;
+    type OnBridgePublisherResult = TestRuntime;
 }
 
 impl system::Config for TestRuntime {
@@ -175,7 +175,7 @@ impl ExtBuilder {
     }
 }
 
-impl OnPublishingResultHandler for TestRuntime {
+impl OnBridgePublisherResult for TestRuntime {
     fn process_result(_tx_id: u32, _tx_succeeded: bool) -> sp_runtime::DispatchResult {
         Ok(())
     }

--- a/pallets/eth-bridge/src/tx.rs
+++ b/pallets/eth-bridge/src/tx.rs
@@ -40,7 +40,7 @@ pub fn finalize_state<T: Config>(
     success: bool,
 ) -> Result<(), Error<T>> {
     // Alert the originating pallet:
-    T::OnPublishingResultHandler::process_result(tx.id, success)
+    T::OnBridgePublisherResult::process_result(tx.id, success)
         .map_err(|_| Error::<T>::HandlePublishingResultFailed)?;
 
     tx.data.tx_succeeded = success;

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -23,7 +23,7 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
-use avn::{AccountToBytesConverter, OnPublishingResultHandler};
+use avn::{AccountToBytesConverter, OnBridgePublisherResult};
 use core::convert::TryInto;
 use frame_support::{dispatch::DispatchResult, ensure, log, traits::Get, weights::Weight};
 use frame_system::{
@@ -1424,7 +1424,7 @@ impl<AccountId> Default for RootData<AccountId> {
     }
 }
 
-impl<T: Config> OnPublishingResultHandler for Pallet<T> {
+impl<T: Config> OnBridgePublisherResult for Pallet<T> {
     fn process_result(_tx_id: u32, _succeeded: bool) -> DispatchResult {
         Ok(())
     }

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -688,7 +688,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type AccountToBytesConvert = Avn;
     type TimeProvider = pallet_timestamp::Pallet<Runtime>;
     type WeightInfo = pallet_eth_bridge::default_weights::SubstrateWeight<Runtime>;
-    type OnPublishingResultHandler = Summary;
+    type OnBridgePublisherResult = Summary;
 }
 
 // Other pallets

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -700,7 +700,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type AccountToBytesConvert = Avn;
     type TimeProvider = pallet_timestamp::Pallet<Runtime>;
     type WeightInfo = pallet_eth_bridge::default_weights::SubstrateWeight<Runtime>;
-    type OnPublishingResultHandler = Summary;
+    type OnBridgePublisherResult = Summary;
 }
 
 // Other pallets


### PR DESCRIPTION
Various fixes to address issues arising during eth-bridge testing:

- Rename exit trait to align with entry trait
- Fix avn invoke method to handle leading slash on url and improve errors
- Fix view response processing for corroborate call
- Fix signing payload for extrinsics to use author's account id instead of entire author

