### PR TITLE
SYS-3773 Rename to allow support for non transaction requests - part 1

### DIFF
--- a/pallets/eth-bridge/src/call.rs
+++ b/pallets/eth-bridge/src/call.rs
@@ -2,14 +2,14 @@ use super::*;
 use crate::{Author, Config};
 use sp_core::{ecdsa, H256};
 
-pub fn add_confirmation<T: Config>(tx_id: u32, confirmation: ecdsa::Signature, author: Author<T>) {
+pub fn add_confirmation<T: Config>(tx_id: EthereumId, confirmation: ecdsa::Signature, author: Author<T>) {
     let proof = add_confirmation_proof::<T>(tx_id, &confirmation, &author.account_id);
     let signature = author.key.sign(&proof).expect("Error signing proof");
     let call = Call::<T>::add_confirmation { tx_id, confirmation, author, signature };
     let _ = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into());
 }
 
-pub fn add_eth_tx_hash<T: Config>(tx_id: u32, eth_tx_hash: H256, author: Author<T>) {
+pub fn add_eth_tx_hash<T: Config>(tx_id: EthereumId, eth_tx_hash: H256, author: Author<T>) {
     let proof = add_eth_tx_hash_proof::<T>(tx_id, &eth_tx_hash, &author.account_id);
     let signature = author.key.sign(&proof).expect("Error signing proof");
     let call = Call::<T>::add_eth_tx_hash { tx_id, eth_tx_hash, author, signature };
@@ -17,7 +17,7 @@ pub fn add_eth_tx_hash<T: Config>(tx_id: u32, eth_tx_hash: H256, author: Author<
 }
 
 pub fn add_corroboration<T: Config>(
-    tx_id: u32,
+    tx_id: EthereumId,
     tx_succeeded: bool,
     tx_hash_is_valid: bool,
     author: Author<T>,
@@ -31,7 +31,7 @@ pub fn add_corroboration<T: Config>(
 }
 
 fn add_confirmation_proof<T: Config>(
-    tx_id: u32,
+    tx_id: EthereumId,
     confirmation: &ecdsa::Signature,
     account_id: &T::AccountId,
 ) -> Vec<u8> {
@@ -39,7 +39,7 @@ fn add_confirmation_proof<T: Config>(
 }
 
 fn add_eth_tx_hash_proof<T: Config>(
-    tx_id: u32,
+    tx_id: EthereumId,
     eth_tx_hash: &H256,
     account_id: &T::AccountId,
 ) -> Vec<u8> {
@@ -47,7 +47,7 @@ fn add_eth_tx_hash_proof<T: Config>(
 }
 
 fn add_corroboration_proof<T: Config>(
-    tx_id: u32,
+    tx_id: EthereumId,
     tx_succeeded: bool,
     tx_hash_is_valid: bool,
     account_id: &T::AccountId,

--- a/pallets/eth-bridge/src/default_weights.rs
+++ b/pallets/eth-bridge/src/default_weights.rs
@@ -73,20 +73,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	// Storage: Avn Validators (r:1 w:0)
 	fn add_confirmation() -> Weight {
 		Weight::from_ref_time(19_577_000)
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	fn add_eth_tx_hash() -> Weight {
 		Weight::from_ref_time(15_108_000)
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	// Storage: Avn Validators (r:1 w:0)
 	fn add_corroboration() -> Weight {
 		Weight::from_ref_time(19_797_000)
@@ -107,20 +107,20 @@ impl WeightInfo for () {
 		Weight::from_ref_time(17_263_000)
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	// Storage: Avn Validators (r:1 w:0)
 	fn add_confirmation() -> Weight {
 		Weight::from_ref_time(19_577_000)
 			.saturating_add(RocksDbWeight::get().reads(2))
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	fn add_eth_tx_hash() -> Weight {
 		Weight::from_ref_time(15_108_000)
 			.saturating_add(RocksDbWeight::get().reads(1))
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
-	// Storage: EthBridge ActiveTransaction (r:1 w:1)
+	// Storage: EthBridge ActiveRequest (r:1 w:1)
 	// Storage: Avn Validators (r:1 w:0)
 	fn add_corroboration() -> Weight {
 		Weight::from_ref_time(19_797_000)

--- a/pallets/eth-bridge/src/eth.rs
+++ b/pallets/eth-bridge/src/eth.rs
@@ -17,7 +17,7 @@ const BYTES: &[u8] = b"bytes";
 const BYTES32: &[u8] = b"bytes32";
 
 pub fn create_tx_data<T: Config>(
-    tx_request: &RequestData,
+    tx_request: &Request,
     expiry: u64,
 ) -> Result<TransactionData<T>, Error<T>> {
     let mut extended_params = unbound_params(&tx_request.params);
@@ -152,7 +152,7 @@ pub fn generate_send_calldata<T: Config>(
     abi_encode_function(&tx.data.function_name.as_slice(), &full_params)
 }
 
-fn generate_corroborate_calldata<T: Config>(tx_id: u32, expiry: u64) -> Result<Vec<u8>, Error<T>> {
+fn generate_corroborate_calldata<T: Config>(tx_id: EthereumId, expiry: u64) -> Result<Vec<u8>, Error<T>> {
     let params = vec![
         (UINT32.to_vec(), tx_id.to_string().into_bytes()),
         (UINT256.to_vec(), expiry.to_string().into_bytes()),

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -146,7 +146,7 @@ fn generate_signature(author: Author<TestRuntime>, context: &[u8]) -> TestSignat
     author.key.sign(&(context).encode()).expect("Signature is signed")
 }
 
-pub fn setup_eth_tx_request(context: &Context) -> u32 {
+pub fn setup_eth_tx_request(context: &Context) -> EthereumId {
     add_new_request::<TestRuntime>(&context.request_function_name, &context.request_params).unwrap()
 }
 
@@ -293,7 +293,7 @@ impl ExtBuilder {
 }
 
 impl OnBridgePublisherResult for TestRuntime {
-    fn process_result(_tx_id: u32, _tx_succeeded: bool) -> sp_runtime::DispatchResult {
+    fn process_result(_tx_id: EthereumId, _tx_succeeded: bool) -> sp_runtime::DispatchResult {
         Ok(())
     }
 }

--- a/pallets/eth-bridge/src/tx.rs
+++ b/pallets/eth-bridge/src/tx.rs
@@ -6,7 +6,7 @@ use sp_core::Get;
 pub fn add_new_request<T: Config>(
     function_name: &[u8],
     params: &[(Vec<u8>, Vec<u8>)],
-) -> Result<u32, Error<T>> {
+) -> Result<EthereumId, Error<T>> {
     let function_name_string =
         String::from_utf8(function_name.to_vec()).map_err(|_| Error::<T>::FunctionNameError)?;
     if function_name_string.is_empty() {
@@ -15,14 +15,14 @@ pub fn add_new_request<T: Config>(
 
     let tx_id = use_next_tx_id::<T>();
 
-    let tx_request = RequestData {
+    let tx_request = Request {
         tx_id,
         function_name: BoundedVec::<u8, FunctionLimit>::try_from(function_name.to_vec())
             .map_err(|_| Error::<T>::ExceedsFunctionNameLimit)?,
         params: bound_params(&params.to_vec())?,
     };
 
-    if ActiveTransaction::<T>::get().is_some() {
+    if ActiveRequest::<T>::get().is_some() {
         queue_tx_request(tx_request)?;
     } else {
         set_up_active_tx(tx_request)?;
@@ -31,8 +31,8 @@ pub fn add_new_request<T: Config>(
     Ok(tx_id)
 }
 
-pub fn is_active<T: Config>(tx_id: u32) -> bool {
-    ActiveTransaction::<T>::get().map_or(false, |active_tx| active_tx.id == tx_id)
+pub fn is_active<T: Config>(tx_id: EthereumId) -> bool {
+    ActiveRequest::<T>::get().map_or(false, |active_tx| active_tx.id == tx_id)
 }
 
 fn replay_transaction<T: Config>(mut tx: ActiveTransactionData<T>) -> Result<(), Error<T>> {
@@ -80,7 +80,7 @@ fn complete_transaction<T: Config>(
     if let Some(tx_request) = dequeue_tx_request::<T>() {
         set_up_active_tx(tx_request)?;
     } else {
-        ActiveTransaction::<T>::kill();
+        ActiveRequest::<T>::kill();
     }
 
     Ok(())
@@ -100,7 +100,7 @@ pub fn finalize_state<T: Config>(
     Ok(complete_transaction::<T>(tx, success)?)
 }
 
-fn queue_tx_request<T: Config>(tx_request: RequestData) -> Result<(), Error<T>> {
+fn queue_tx_request<T: Config>(tx_request: Request) -> Result<(), Error<T>> {
     RequestQueue::<T>::mutate(|maybe_queue| {
         let mut queue: Vec<_> = maybe_queue.clone().unwrap_or_else(Default::default).into();
 
@@ -116,7 +116,7 @@ fn queue_tx_request<T: Config>(tx_request: RequestData) -> Result<(), Error<T>> 
     })
 }
 
-fn dequeue_tx_request<T: Config>() -> Option<RequestData> {
+fn dequeue_tx_request<T: Config>() -> Option<Request> {
     let mut queue = <RequestQueue<T>>::take();
 
     let next_tx_request = match &mut queue {
@@ -133,12 +133,12 @@ fn dequeue_tx_request<T: Config>() -> Option<RequestData> {
     next_tx_request
 }
 
-fn set_up_active_tx<T: Config>(tx_request: RequestData) -> Result<(), Error<T>> {
+fn set_up_active_tx<T: Config>(tx_request: Request) -> Result<(), Error<T>> {
     let expiry = util::time_now::<T>() + EthTxLifetimeSecs::<T>::get();
     let data = eth::create_tx_data(&tx_request, expiry)?;
     let msg_hash = eth::generate_msg_hash(&data)?;
 
-    ActiveTransaction::<T>::put(ActiveTransactionData {
+    ActiveRequest::<T>::put(ActiveTransactionData {
         id: tx_request.tx_id,
         request_data: tx_request,
         data,
@@ -155,7 +155,7 @@ fn set_up_active_tx<T: Config>(tx_request: RequestData) -> Result<(), Error<T>> 
     Ok(())
 }
 
-fn use_next_tx_id<T: Config>() -> u32 {
+fn use_next_tx_id<T: Config>() -> EthereumId {
     let tx_id = NextTxId::<T>::get();
     NextTxId::<T>::put(tx_id + 1);
     tx_id


### PR DESCRIPTION
This PP changes the following (no functionality changes):
 - updates `u32` -> `EthereumId`
 - renames `ActiveTransaction` -> `ActiveRequest`
 - renames `RequestData` -> `Request`

The rational behind the rename is to separate Transaction requests (sending a transaction to Ethereum) and lower proof requests (generating proofs for lower)